### PR TITLE
[Refactor/searchBar-10] 🔨 Refactor: 헤더 검색바 컴포넌트 리팩토링

### DIFF
--- a/src/components/header/components/HeaderSearchBar.tsx
+++ b/src/components/header/components/HeaderSearchBar.tsx
@@ -1,104 +1,43 @@
-import { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import searchIcon from '@/assets/icons/header/search-icon.svg';
-import { SEARCH_ITEMS, SearchItem } from '@/constants/search-items';
+import { useSearchBar } from '@/hooks/useSearchBar';
+import SearchInput from './SearchInput';
+import SearchResultList from './SearchResultList';
 import {
   Popover,
-  PopoverContent,
   PopoverTrigger,
+  PopoverContent,
 } from '@/components/ui/popover';
 
 const HeaderSearchBar = () => {
-  const [open, setOpen] = useState(false);
-  const [query, setQuery] = useState('');
-  const navigate = useNavigate();
-
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault();
-        setOpen((open) => !open);
-      }
-    };
-
-    document.addEventListener('keydown', down);
-    return () => document.removeEventListener('keydown', down);
-  }, []);
-
-  const handleSelect = (item: SearchItem) => {
-    setOpen(false);
-    setQuery('');
-    navigate(item.path);
-  };
+  const { open, setOpen, query, setQuery, filteredItems, handleSelect } =
+    useSearchBar();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
     setQuery(e.target.value);
   };
 
-  const handleInputClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const handleInputFocus = () => {
     setOpen(true);
   };
-
-  const filteredItems = SEARCH_ITEMS.filter(
-    (item) =>
-      item.category === '서비스 자원' &&
-      (query === '' ||
-        item.title.toLowerCase().includes(query.toLowerCase()) ||
-        item.description.toLowerCase().includes(query.toLowerCase())),
-  );
 
   return (
     <Popover
       open={open}
       onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <div className='flex items-center gap-2 p-2 bg-white/20 rounded-full cursor-pointer pointer-events-auto'>
-          <input
-            value={query}
-            onChange={handleInputChange}
-            onClick={handleInputClick}
-            className='bg-transparent outline-none px-2 text-white text-left w-full placeholder:text-white/50 cursor-text relative z-15'
-            placeholder='기능 검색...'
-            type='text'
-          />
-          <div className='rounded-full p-2 bg-white/80 hover:bg-white/50 transition-all duration-300 shrink-0'>
-            <img
-              src={searchIcon}
-              alt='search'
-            />
-          </div>
-        </div>
+        <SearchInput
+          value={query}
+          onChange={handleInputChange}
+          onFocus={handleInputFocus}
+        />
       </PopoverTrigger>
       <PopoverContent
         className='w-[300px] p-0'
         align='start'
         sideOffset={5}>
-        <div className='max-h-[300px] overflow-auto rounded-lg bg-white'>
-          {filteredItems.length === 0 ? (
-            <div className='py-6 text-center text-sm text-gray-500'>
-              검색 결과가 없습니다.
-            </div>
-          ) : (
-            <div className='p-2'>
-              <div className='px-2 py-1.5 text-sm font-medium text-gray-500'>
-                서비스 자원
-              </div>
-              {filteredItems.map((item) => (
-                <div
-                  key={item.id}
-                  onClick={() => handleSelect(item)}
-                  className='px-2 py-1.5 rounded-md cursor-pointer hover:bg-blue-50'>
-                  <div className='font-medium text-gray-700'>{item.title}</div>
-                  <div className='text-sm text-gray-500'>
-                    {item.description}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <SearchResultList
+          items={filteredItems}
+          onSelect={handleSelect}
+        />
       </PopoverContent>
     </Popover>
   );

--- a/src/components/header/components/HeaderSearchBar.tsx
+++ b/src/components/header/components/HeaderSearchBar.tsx
@@ -8,8 +8,15 @@ import {
 } from '@/components/ui/popover';
 
 const HeaderSearchBar = () => {
-  const { open, setOpen, query, setQuery, filteredItems, handleSelect } =
-    useSearchBar();
+  const {
+    open,
+    setOpen,
+    query,
+    setQuery,
+    filteredItems,
+    handleSelect,
+    selectedIndex,
+  } = useSearchBar();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setQuery(e.target.value);
@@ -37,6 +44,7 @@ const HeaderSearchBar = () => {
         <SearchResultList
           items={filteredItems}
           onSelect={handleSelect}
+          selectedIndex={selectedIndex}
         />
       </PopoverContent>
     </Popover>

--- a/src/components/header/components/SearchInput.tsx
+++ b/src/components/header/components/SearchInput.tsx
@@ -1,0 +1,33 @@
+import React, { forwardRef } from 'react';
+import searchIcon from '@/assets/icons/header/search-icon.svg';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onFocus: () => void;
+}
+
+const SearchInput = forwardRef<HTMLDivElement, SearchInputProps>(
+  ({ value, onChange, onFocus }, ref) => (
+    <div
+      ref={ref}
+      className='flex items-center gap-2 p-2 bg-white/20 rounded-full cursor-pointer pointer-events-auto'>
+      <input
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        className='bg-transparent outline-none px-2 text-white text-left w-full placeholder:text-white/50 cursor-text relative z-15'
+        placeholder='기능 검색...'
+        type='text'
+      />
+      <div className='rounded-full p-2 bg-white/80 hover:bg-white/50 transition-all duration-300 shrink-0'>
+        <img
+          src={searchIcon}
+          alt='search'
+        />
+      </div>
+    </div>
+  ),
+);
+
+export default SearchInput;

--- a/src/components/header/components/SearchPopover.tsx
+++ b/src/components/header/components/SearchPopover.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+
+interface SearchPopoverProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  children: React.ReactNode;
+}
+
+const SearchPopover = ({
+  open,
+  onOpenChange,
+  children,
+}: SearchPopoverProps) => (
+  <Popover
+    open={open}
+    onOpenChange={onOpenChange}>
+    {children}
+  </Popover>
+);
+
+export { PopoverTrigger, PopoverContent };
+export default SearchPopover;

--- a/src/components/header/components/SearchResultList.tsx
+++ b/src/components/header/components/SearchResultList.tsx
@@ -3,9 +3,14 @@ import { SearchItem } from '@/constants/search-items';
 interface SearchResultListProps {
   items: SearchItem[];
   onSelect: (item: SearchItem) => void;
+  selectedIndex: number;
 }
 
-const SearchResultList = ({ items, onSelect }: SearchResultListProps) => (
+const SearchResultList = ({
+  items,
+  onSelect,
+  selectedIndex,
+}: SearchResultListProps) => (
   <div className='max-h-[300px] overflow-auto rounded-lg bg-white'>
     {items.length === 0 ? (
       <div className='py-6 text-center text-sm text-gray-500'>
@@ -16,11 +21,15 @@ const SearchResultList = ({ items, onSelect }: SearchResultListProps) => (
         <div className='px-2 py-1.5 text-sm font-medium text-gray-500'>
           서비스 자원
         </div>
-        {items.map((item) => (
+        {items.map((item, index) => (
           <div
             key={item.id}
             onClick={() => onSelect(item)}
-            className='px-2 py-1.5 rounded-md cursor-pointer hover:bg-blue-50'>
+            className={`px-2 py-1.5 rounded-md cursor-pointer ${
+              index === selectedIndex
+                ? 'bg-blue-50 text-blue-600'
+                : 'hover:bg-blue-50'
+            }`}>
             <div className='font-medium text-gray-700'>{item.title}</div>
             <div className='text-sm text-gray-500'>{item.description}</div>
           </div>

--- a/src/components/header/components/SearchResultList.tsx
+++ b/src/components/header/components/SearchResultList.tsx
@@ -1,0 +1,33 @@
+import { SearchItem } from '@/constants/search-items';
+
+interface SearchResultListProps {
+  items: SearchItem[];
+  onSelect: (item: SearchItem) => void;
+}
+
+const SearchResultList = ({ items, onSelect }: SearchResultListProps) => (
+  <div className='max-h-[300px] overflow-auto rounded-lg bg-white'>
+    {items.length === 0 ? (
+      <div className='py-6 text-center text-sm text-gray-500'>
+        검색 결과가 없습니다.
+      </div>
+    ) : (
+      <div className='p-2'>
+        <div className='px-2 py-1.5 text-sm font-medium text-gray-500'>
+          서비스 자원
+        </div>
+        {items.map((item) => (
+          <div
+            key={item.id}
+            onClick={() => onSelect(item)}
+            className='px-2 py-1.5 rounded-md cursor-pointer hover:bg-blue-50'>
+            <div className='font-medium text-gray-700'>{item.title}</div>
+            <div className='text-sm text-gray-500'>{item.description}</div>
+          </div>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+export default SearchResultList;

--- a/src/hooks/useSearchBar.ts
+++ b/src/hooks/useSearchBar.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SEARCH_ITEMS, SearchItem } from '@/constants/search-items';
 
@@ -8,11 +8,14 @@ export function useSearchBar() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const navigate = useNavigate();
 
-  const handleSelect = (item: SearchItem) => {
-    setOpen(false);
-    setQuery('');
-    navigate(item.path);
-  };
+  const handleSelect = useCallback(
+    (item: SearchItem) => {
+      setOpen(false);
+      setQuery('');
+      navigate(item.path);
+    },
+    [navigate, setOpen, setQuery],
+  );
 
   const filteredItems = SEARCH_ITEMS.filter(
     (item) =>

--- a/src/hooks/useSearchBar.ts
+++ b/src/hooks/useSearchBar.ts
@@ -1,10 +1,11 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { SEARCH_ITEMS, SearchItem } from '@/constants/search-items';
 
 export function useSearchBar() {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState('');
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const navigate = useNavigate();
 
   const handleSelect = (item: SearchItem) => {
@@ -21,6 +22,44 @@ export function useSearchBar() {
         item.description.toLowerCase().includes(query.toLowerCase())),
   );
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!open) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            prev < filteredItems.length - 1 ? prev + 1 : prev,
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : prev));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (filteredItems[selectedIndex]) {
+            handleSelect(filteredItems[selectedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setOpen(false);
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, filteredItems, selectedIndex, handleSelect]);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedIndex(0);
+    }
+  }, [open]);
+
   return {
     open,
     setOpen,
@@ -28,5 +67,6 @@ export function useSearchBar() {
     setQuery,
     filteredItems,
     handleSelect,
+    selectedIndex,
   };
 }

--- a/src/hooks/useSearchBar.ts
+++ b/src/hooks/useSearchBar.ts
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { SEARCH_ITEMS, SearchItem } from '@/constants/search-items';
+
+export function useSearchBar() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+
+  const handleSelect = (item: SearchItem) => {
+    setOpen(false);
+    setQuery('');
+    navigate(item.path);
+  };
+
+  const filteredItems = SEARCH_ITEMS.filter(
+    (item) =>
+      item.category === '서비스 자원' &&
+      (query === '' ||
+        item.title.toLowerCase().includes(query.toLowerCase()) ||
+        item.description.toLowerCase().includes(query.toLowerCase())),
+  );
+
+  return {
+    open,
+    setOpen,
+    query,
+    setQuery,
+    filteredItems,
+    handleSelect,
+  };
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Refactor/searchBar-10` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
기존 HeaderSearchBar 컴포넌트에 UI와 로직이 집중되어 있어 컴포넌트 분할 및 로직을 분리 및 키보드 이벤트 추가

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] UI와 로직 분리
  - [x] 커스텀 훅 생성 `useSearchBar.ts`
  - [x] `useSearchBar.ts` handleSelect 함수 불필요한 리렌더링 방지 (useCallback 사용)
  - [x] PopoverTrigger 및 PopoverContent 컴포넌트 분리
- [x] key 이벤트 추가 (방향키 및 엔터로 페이지 이동)

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#10