### PR TITLE
[Feature/Sidebar-22] :sparkles:Feature: 사이드바 확장<->축소 여부 로컬스토리지에 저장하는 기능 추가

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,25 +1,21 @@
-import { useState } from 'react';
-import hamburgerIcon from '@/assets/icons/sidebar/hamburger-menu-icon.svg';
 import MenuList from './components/MenuList';
+import SidebarToggle from './components/SidebarToggle';
+import useLocalStorage from '@/hooks/useLocalStorage';
+
+const SIDEBAR_STATE_KEY = 'sidebar-expanded';
+
 const Sidebar = () => {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useLocalStorage(SIDEBAR_STATE_KEY, true);
 
   return (
     <aside
-      className={`h-screen bg-[#F9F9F9] transition-all duration-200 flex flex-col  gap-4 py-4
+      className={`h-screen bg-[#F9F9F9] transition-all duration-200 flex flex-col gap-4 py-4
         ${isExpanded ? 'w-52 items-start' : 'w-20 items-center'}
       `}>
-      <button
-        className={`text-2xl cursor-pointer select-none ${
-          isExpanded ? 'ml-6' : ''
-        }`}
-        onClick={() => setIsExpanded((prev) => !prev)}>
-        <img
-          src={hamburgerIcon}
-          alt='hamburger-menu-icon'
-          className='[-webkit-user-drag:none] select-none pointer-events-none'
-        />
-      </button>
+      <SidebarToggle
+        isExpanded={isExpanded}
+        onToggle={() => setIsExpanded((prev) => !prev)}
+      />
       <MenuList isExpanded={isExpanded} />
     </aside>
   );

--- a/src/components/sidebar/components/SidebarToggle.tsx
+++ b/src/components/sidebar/components/SidebarToggle.tsx
@@ -1,0 +1,24 @@
+import hamburgerIcon from '@/assets/icons/sidebar/hamburger-menu-icon.svg';
+
+interface SidebarToggleProps {
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+const SidebarToggle = ({ isExpanded, onToggle }: SidebarToggleProps) => {
+  return (
+    <button
+      className={`text-2xl cursor-pointer select-none ${
+        isExpanded ? 'ml-6' : ''
+      }`}
+      onClick={onToggle}>
+      <img
+        src={hamburgerIcon}
+        alt='hamburger-menu-icon'
+        className='[-webkit-user-drag:none] select-none pointer-events-none'
+      />
+    </button>
+  );
+};
+
+export default SidebarToggle;

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from 'react';
+
+function useLocalStorage<T>(key: string, initialValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    try {
+      const savedValue = localStorage.getItem(key);
+      return savedValue ? JSON.parse(savedValue) : initialValue;
+    } catch (error) {
+      console.error('로컬 스토리지에서 값을 불러올 수 없습니다.', error);
+      return initialValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.error('로컬 스토리지에 값을 저장할 수 없습니다.', error);
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}
+
+export default useLocalStorage;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Feature/Sidebar-22` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
사이드바 설정(확장 <-> 축소) 로컬스토리지에 저장 및 불러오는 기능 추가

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] 사이드바 토글 버튼 컴포넌트 분리 (`SidebarToggle.tsx`)
- [x] 로컬스토리지 관리를 위한 커스텀 훅 생성 (`useLocalStorage.ts`)
- [x] 사이드바 컴포넌트 리팩토링 (`Sidebar.tsx`)

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
사이드바 설정은 단발성이 아니라 영구적인 것에 가까워서 로컬 스토리지를 클리어하는 코드는 따로 구현하지 않았습니다.

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#22