### PR TITLE
[Style/userdashboard-28] 💄 Style : 사용자 분석 퍼블리싱

### DIFF
--- a/src/components/table/TableFooter.tsx
+++ b/src/components/table/TableFooter.tsx
@@ -28,11 +28,15 @@ const TableFooter = ({ onAddItem, buttonText }: TableFooterProps) => {
           </PaginationItem>
         </PaginationContent>
       </Pagination>
-      <Button
-        className='bg-gradient-to-r from-[#888CFC] to-[#93B9FF] text-white px-6 py-3 rounded-full cursor-pointer'
-        onClick={onAddItem}>
-        {buttonText}
-      </Button>
+      {/* 버튼 */}
+      {onAddItem && buttonText && (
+        <Button
+          className="bg-gradient-to-r from-[#888CFC] to-[#93B9FF] text-white px-6 py-3 rounded-full cursor-pointer"
+          onClick={onAddItem}
+        >
+          {buttonText}
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/constants/user-dashboard/userActivity.ts
+++ b/src/constants/user-dashboard/userActivity.ts
@@ -1,0 +1,64 @@
+import { ColumnDef } from '@tanstack/react-table'
+import { UserActivityItem } from '../../types/user-dashboard'
+
+export const USER_ACTIVITY_COLUMNS: ColumnDef<UserActivityItem>[] = [
+  {
+    accessorKey: 'nickname',
+    header: '닉네임',
+  },
+  {
+    accessorKey: 'email',
+    header: 'ID/이메일',
+  },
+  {
+    accessorKey: 'lastActive',
+    header: '마지막 접속 시간',
+  },
+  {
+    accessorKey: 'url',
+    header: '가장 많이 접속한 기능 (url)',
+  },
+  {
+    accessorKey: 'browser',
+    header: '접속 브라우저',
+  },
+  {
+    accessorKey: 'joinedAt',
+    header: '최초 가입일',
+  },
+]
+
+export const MOCK_USER_DATA: UserActivityItem[] = [
+  {
+    nickname: '구름이',
+    email: 'test02@naver.com',
+    lastActive: '오늘, PM 04:20',
+    url: 'https://www.room-e.com/1002',
+    browser: 'chrome',
+    joinedAt: '2025-04-24',
+  },
+  {
+    nickname: '구름이',
+    email: 'test02@naver.com',
+    lastActive: '오늘, PM 04:20',
+    url: 'https://www.room-e.com/1002',
+    browser: 'chrome',
+    joinedAt: '2025-04-24',
+  },
+  {
+    nickname: '구름이',
+    email: 'test02@naver.com',
+    lastActive: '오늘, PM 04:20',
+    url: 'https://www.room-e.com/1002',
+    browser: 'chrome',
+    joinedAt: '2025-04-24',
+  },
+  {
+    nickname: '구름이',
+    email: 'test02@naver.com',
+    lastActive: '오늘, PM 04:20',
+    url: 'https://www.room-e.com/1002',
+    browser: 'chrome',
+    joinedAt: '2025-04-24',
+  },
+]

--- a/src/pages/user-dashboard/UserDashboard.tsx
+++ b/src/pages/user-dashboard/UserDashboard.tsx
@@ -1,0 +1,11 @@
+import RankingUserList from "./components/RankingUserList";
+import UserActivity from "./components/UserActivity";
+
+export default function UserDashboard() {
+  return (
+    <main className="flex gap-10">
+      <UserActivity />
+      <RankingUserList />
+    </main>
+  )
+}

--- a/src/pages/user-dashboard/UserDashboard.tsx
+++ b/src/pages/user-dashboard/UserDashboard.tsx
@@ -3,7 +3,7 @@ import UserActivity from "./components/UserActivity";
 
 export default function UserDashboard() {
   return (
-    <main className="flex gap-10">
+    <main className="flex gap-10 items-baseline ">
       <UserActivity />
       <RankingUserList />
     </main>

--- a/src/pages/user-dashboard/components/RankingUserItem.tsx
+++ b/src/pages/user-dashboard/components/RankingUserItem.tsx
@@ -1,0 +1,114 @@
+import defaultImage from '@/assets/images/default-profile-img.jpg';
+import { Avatar, AvatarFallback, AvatarImage } from '@radix-ui/react-avatar';
+import { ArrowDown, ArrowUp } from 'lucide-react';
+import { Card } from '../../../components/ui/card';
+
+export default function RankingUserItem() {
+  const rankingData = [
+    {
+      id: '1',
+      name: '구름이',
+      score: 320,
+      diff: 50,
+      img: '',
+    },
+    {
+      id: '2',
+      name: '하늘이',
+      score: 210,
+      diff: -32,
+      img: '',
+    },
+    {
+      id: '3',
+      name: '바람이',
+      score: 199,
+      diff: -60,
+      img: '',
+    },
+    {
+      id: '4',
+      name: '분이라',
+      score: 100,
+      diff: -60,
+      img: '',
+    },
+    {
+      id: '5',
+      name: '총총총',
+      score: 100,
+      diff: -60,
+      img: '',
+    },
+    {
+      id: '6',
+      name: '땀땀땀',
+      score: 100,
+      diff: -60,
+      img: '',
+    },
+    {
+      id: '7',
+      name: '잠잠잠',
+      score: 199,
+      diff: -60,
+      img: '',
+    },
+    {
+      id: '8',
+      name: '슥슥슥',
+      score: 199,
+      diff: 60,
+      img: '',
+    },
+    {
+      id: '9',
+      name: '깡총이',
+      score: 199,
+      diff: -60,
+      img: '',
+    },
+  ];
+  return (
+    <Card className='w-full px-8 space-y-2 h-[calc(100vh-220px)] overflow-y-auto'>
+      {rankingData.map((user, index) => {
+        const isTop3 = index < 3;
+        const rankColor = isTop3
+          ? ['bg-yellow-400', 'bg-gray-400', 'bg-amber-600'][index]
+          : 'bg-gray-300 text-muted-foreground';
+
+        return (
+          <div
+            key={user.id}
+            className={`flex items-center gap-3 pb-4 mb-2 ${index < rankingData.length - 1 ? 'border-b-2 border-muted/70' : ''}`}>
+            {/* 순위 */}
+            <div
+              className={`w-6 h-6 flex items-center justify-center rounded-full text-xs font-bold text-white ${rankColor}`}>
+              {index + 1}
+            </div>
+            <Avatar>
+              <AvatarImage
+                src={user.img || defaultImage}
+                className='rounded-full w-9 h-9 border-1'
+              />
+              <AvatarFallback>{user.name[0]}</AvatarFallback>
+            </Avatar>
+            <div className='flex-1'>
+              <div className='flex justify-between text-sm font-medium'>
+                <span>{user.name}</span>
+                <div className='flex items-center gap-1 text-muted-foreground text-xs'>
+                  <span>{user.score}</span>
+                  {user.diff > 0 ? (
+                    <ArrowUp className='w-3 h-3 text-red-500' />
+                  ) : (
+                    <ArrowDown className='w-3 h-3 text-blue-500' />
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </Card>
+  );
+}

--- a/src/pages/user-dashboard/components/RankingUserList.tsx
+++ b/src/pages/user-dashboard/components/RankingUserList.tsx
@@ -1,0 +1,34 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@radix-ui/react-tooltip';
+import { Info } from 'lucide-react';
+import RankingUserItem from './RankingUserItem';
+
+
+export default function RankingUserList() {
+  return (
+    <section className='flex flex-col w-full gap-4 '>
+      {/* 랭킹 헤더 */}
+      <div className='flex items-center gap-2 '>
+        <h2 className='text-xl font-bold text-[#545454]'>이번주 랭킹 유저</h2>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className='w-5 h-5 text-[#afaeae] cursor-pointer' />
+            </TooltipTrigger>
+            <TooltipContent
+              side='right'
+              sideOffset={10}>
+              <p className=' border-1 border-[#213B6B/20] mb-5 px-4 py-2 text-sm font-medium text-[#213B6B] bg-white shadow-sm rounded-tr-md rounded-br-md rounded-tl-md' >1시간 마다 갱신됩니다.</p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+      {/* 랭킹 */}
+      <RankingUserItem />
+    </section>
+  );
+}

--- a/src/pages/user-dashboard/components/UserActivity.tsx
+++ b/src/pages/user-dashboard/components/UserActivity.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+import { TableFooter, TableHeader } from '../../../components/table';
+import { ActivityIcon } from 'lucide-react';
+import { UserActivityItem } from '../../../types/user-dashboard';
+import UserActivityTable from './UserActivityTable';
+import { MOCK_USER_DATA } from '../../../constants/user-dashboard/userActivity';
+
+export default function UserActivity() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [data, setData] = useState<UserActivityItem[]>([])
+
+  useEffect(() => {
+  setData(MOCK_USER_DATA);
+  setIsLoading(false);
+}, []);
+
+
+  return (
+    <section>
+      <TableHeader
+        icon={ActivityIcon}
+        title='최근 사용자 활동'
+        tabs={[
+          { value: 'name', label: '이름순' },
+          { value: 'date', label: '가입순' },
+        ]}
+        defaultTab='name'
+      />
+      <UserActivityTable data={data} isLoading={isLoading}  />
+      <TableFooter/>
+    </section>
+  );
+}

--- a/src/pages/user-dashboard/components/UserActivityTable.tsx
+++ b/src/pages/user-dashboard/components/UserActivityTable.tsx
@@ -1,0 +1,28 @@
+import { getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { UserActivityItem } from '../../../types/user-dashboard';
+import { USER_ACTIVITY_COLUMNS } from '../../../constants/user-dashboard/userActivity';
+import { Table } from '../../../components/table';
+
+interface UserActivityTableProps {
+  data: UserActivityItem[];
+  isLoading: boolean;
+}
+
+export default function UserActivityTable({
+  data,
+  isLoading,
+}: UserActivityTableProps) {
+  const table = useReactTable({
+    data,
+    columns: USER_ACTIVITY_COLUMNS,
+    getCoreRowModel: getCoreRowModel(),
+  });
+  return (
+    <>
+      <Table
+        table={table}
+        isLoading={isLoading}
+      />
+    </>
+  );
+}

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -10,6 +10,7 @@ import EditProfile from '@/pages/mypage/EditProfile';
 import Mypage from '../pages/mypage/Mypage';
 import BaseLayout from './layout/BaseLayout';
 import DashboardLayout from './layout/DashboardLayout';
+import UserDashboard from '../pages/user-dashboard/UserDashboard';
 
 const Router = () => {
   return (
@@ -56,7 +57,7 @@ const Router = () => {
           path='service'
           element={<ServiceDashboard />}
         />
-        {/* <Route path='user' element={< UserDashboard />} /> */}
+        <Route path='user' element={< UserDashboard />} />
         {/* <Route path='system' element={< SystemDashboard />} /> */}
       </Route>
 

--- a/src/types/components/table.d.ts
+++ b/src/types/components/table.d.ts
@@ -9,8 +9,8 @@ interface TableHeaderProps {
 }
 
 interface TableFooterProps {
-  onAddItem: () => void;
-  buttonText: string;
+  onAddItem?: () => void;
+  buttonText?: string;
 }
 
 type AdminRole = '운영 관리자' | '시스템 관리자' | '일반 관리자';

--- a/src/types/user-dashboard.d.ts
+++ b/src/types/user-dashboard.d.ts
@@ -1,0 +1,9 @@
+
+export interface UserActivityItem{
+  nickname: string
+  email: string
+  lastActive: string
+  url: string
+  browser: string
+  joinedAt: string
+}


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Style/userdashboard-28` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
사용자 분석 페이지 퍼블리싱

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] TableFooter - 코드 수정
  - `Table.d.ts` - `onAddItem` , `buttonText` 옵셔널 추가
  - 그에 따라 `button` 의 경우 조건부 렌더링 처리

- [x] UserDashboard,tsx
  - `UserActivity.tsx` - 최근 사용자 활동
    - `TableHeader/TableFooter` 사용
    - `UserActivityTable.tsx` - `Table` 사용
  - `RankingUserList.tsx` - 이번주 랭킹 유저
    - `RankingUserItem.tsx` - 랭킹별 유저 목록

- [x] `userActivity.ts` - 리스트 컬럼 상수 파일로 분리 

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 최근 사용자 활동 리스트 정렬 기능이 현재 `[이름순/가입순]` 인데 `[접속순/가입순]` 으로 변경하면 더 유용하지 않을까요?
- `Table` 이 반응형이 안되어 있는 것 같아서 추후에 수정하면 좋을 것 같습니다!
- 디자인에서 랭킹에 `progress`가 있었는데, 불필요한 요소인 것 같아 제거했습니다.
- 퍼블리싱을 위해 목업 데이터를 넣어두었습니다. 추후 삭제 예정

![스크린샷 2025-06-28 오전 1 14 42](https://github.com/user-attachments/assets/43be2133-5c3e-4e8e-a528-7f8d180ab4d4)


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#28 