### PR TITLE
[Style/ServiceDashboard-32] :lipstick:Style: 한달 리포트 요약 더보기 페이지 퍼블리싱 / 서비스 대시보드 반응형 추가

### DIFF
--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -17,7 +17,7 @@ const ServiceDashboard = () => {
         title='서비스 대시보드'
         tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
       />
-      <div className='grid grid-cols-[1fr_320px] gap-6 mb-12'>
+      <div className='grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6 mb-12'>
         <StatCardGrid
           selectedCard={selectedCard}
           onCardSelect={handleCardSelect}

--- a/src/pages/service-dashboard/components/ServiceReport.tsx
+++ b/src/pages/service-dashboard/components/ServiceReport.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Card } from '@/components/ui/card';
 import {
   Select,
@@ -8,54 +9,66 @@ import {
 } from '@/components/ui/select';
 
 import SparklesIcon from '@/assets/icons/service-dashboard/sparkle-icon.svg?react';
+import SmartReportModal from './SmartReportModal';
 
 const ServiceReport = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <Card className='h-full p-4 flex flex-col shadow-none rounded-lg'>
-      <div className='flex items-center justify-between'>
-        <h2 className='text-lg font-medium text-[#4983EF] flex items-center gap-2'>
-          한달 리포트 요약
-          <SparklesIcon className='w-4 h-4 opacity-50 ' />
-        </h2>
-        <Select defaultValue='month'>
-          <SelectTrigger className='w-[100px] bg-white shadow-none'>
-            <SelectValue placeholder='한달' />
-          </SelectTrigger>
-          <SelectContent className='w-[100px] min-w-[100px]'>
-            <SelectItem value='month'>한달</SelectItem>
-            <SelectItem value='week'>일주일</SelectItem>
-            <SelectItem value='day'>하루</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
+    <>
+      <Card className='h-full p-4 flex flex-col shadow-none rounded-lg'>
+        <div className='flex items-center justify-between'>
+          <h2 className='text-lg font-medium text-[#4983EF] flex items-center gap-2'>
+            한달 리포트 요약
+            <SparklesIcon className='w-4 h-4 opacity-50 ' />
+          </h2>
+          <Select defaultValue='month'>
+            <SelectTrigger className='w-[100px] bg-white shadow-none'>
+              <SelectValue placeholder='한달' />
+            </SelectTrigger>
+            <SelectContent className='w-[100px] min-w-[100px]'>
+              <SelectItem value='month'>한달</SelectItem>
+              <SelectItem value='week'>일주일</SelectItem>
+              <SelectItem value='day'>하루</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
 
-      <div className='w-full bg-blue-50 rounded-full py-2 px-4 text-center text-gray-600 font-medium'>
-        <Select defaultValue='04'>
-          <SelectTrigger className='w-full bg-transparent border-none text-center text-lg font-medium shadow-none cursor-default'>
-            <SelectValue placeholder='월 선택' />
-          </SelectTrigger>
-          <SelectContent>
-            {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
-              <SelectItem
-                key={month}
-                value={month.toString().padStart(2, '0')}>
-                {month}월
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
+        <div className='w-full bg-blue-50 rounded-full py-2 px-4 text-center text-gray-600 font-medium'>
+          <Select defaultValue='04'>
+            <SelectTrigger className='w-full bg-transparent border-none text-center text-lg font-medium shadow-none cursor-default'>
+              <SelectValue placeholder='월 선택' />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                <SelectItem
+                  key={month}
+                  value={month.toString().padStart(2, '0')}>
+                  {month}월
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
 
-      <div className='flex-1 flex flex-col justify-center space-y-1 text-gray-600 py-1'>
-        <p>1. 가장 많이 사용한 기능은 000 입니다.</p>
-        <p>2. 가장 이탈률이 많은 기능은 000 입니다.</p>
-        <p>3. 0000 경로에서 가장 많은 사용자가 유입되었습니다.</p>
-      </div>
+        <div className='flex-1 flex flex-col justify-center space-y-1 text-gray-600 py-1'>
+          <p>1. 가장 많이 사용한 기능은 000 입니다.</p>
+          <p>2. 가장 이탈률이 많은 기능은 000 입니다.</p>
+          <p>3. 0000 경로에서 가장 많은 사용자가 유입되었습니다.</p>
+        </div>
 
-      <button className='w-full py-3 text-gray-500 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors cursor-pointer'>
-        더보기
-      </button>
-    </Card>
+        <button
+          onClick={() => setIsModalOpen(true)}
+          className='w-full py-3 text-gray-500 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors cursor-pointer'>
+          더보기
+        </button>
+      </Card>
+
+      <SmartReportModal
+        open={isModalOpen}
+        onOpenChange={setIsModalOpen}
+      />
+    </>
   );
 };
 

--- a/src/pages/service-dashboard/components/SmartReportModal.tsx
+++ b/src/pages/service-dashboard/components/SmartReportModal.tsx
@@ -1,0 +1,135 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import SparklesIcon from '@/assets/icons/service-dashboard/sparkle-icon.svg?react';
+
+interface SmartReportModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SmartReportModal = ({ open, onOpenChange }: SmartReportModalProps) => {
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={onOpenChange}>
+      <DialogContent className='max-w-lg p-6'>
+        <DialogHeader className='flex flex-row items-center justify-between space-y-0 p-4 pb-0'>
+          <DialogTitle className='text-lg font-medium text-[#4983EF] flex items-center gap-2'>
+            스마트 리포트
+            <SparklesIcon className='w-4 h-4 opacity-50' />
+          </DialogTitle>
+          <Select defaultValue='1month'>
+            <SelectTrigger className='w-[85px] bg-white shadow-none border-gray-300 text-sm'>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='1month'>1개월</SelectItem>
+              <SelectItem value='3month'>3개월</SelectItem>
+              <SelectItem value='6month'>6개월</SelectItem>
+              <SelectItem value='1year'>1년</SelectItem>
+            </SelectContent>
+          </Select>
+        </DialogHeader>
+
+        {/* 날짜 표시 */}
+        <div className='w-full bg-blue-50 rounded-full py-2 px-4 text-center text-gray-600 font-medium'>
+          <Select defaultValue='04'>
+            <SelectTrigger className='w-full bg-transparent border-none text-center text-lg font-medium shadow-none cursor-default'>
+              <SelectValue placeholder='월 선택' />
+            </SelectTrigger>
+            <SelectContent>
+              {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
+                <SelectItem
+                  key={month}
+                  value={month.toString().padStart(2, '0')}>
+                  {month}월
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* 주목할 주요 소식 */}
+        <div className='space-y-5'>
+          <h3 className='text-base font-semibold text-gray-800'>
+            주목할 주요 소식
+          </h3>
+
+          <div className='space-y-5'>
+            {/* 첫 번째 소식 */}
+            <div className='space-y-2'>
+              <p className='font-medium text-gray-800 text-sm'>
+                1. 최근 3개월 이내 가장 많이 사용하는 기능은 000 입니다.
+              </p>
+              <div className='text-xs text-gray-600 space-y-1 pl-3'>
+                <p>- 수치 : 이용횟수 (클릭이나 볼륨 만족했을 때 사용량)</p>
+                <p>- 수집내강 개인정보 (본 위의의 작 철때 개인정보)</p>
+                <p>- 보유이용기간 (수집 시~위의내용일로부터 6개월)</p>
+                <p>
+                  - 동의를 거부할 권리가 있으며, 동의 거부에 따라
+                  불이익(민원신청 불가) 조치 등 있을 수 있음
+                </p>
+              </div>
+            </div>
+
+            {/* 두 번째 소식 */}
+            <div className='space-y-2'>
+              <p className='font-medium text-gray-800 text-sm'>
+                2. 가장 이탈률이 많은 기능은 000 입니다.
+              </p>
+              <div className='text-xs text-gray-600 space-y-1 pl-3'>
+                <p>- 수치 : 이용횟수 (클릭이나 볼륨 만족했을 때 사용량)</p>
+                <p>- 수집내강 개인정보 (본 위의의 작 철때 개인정보)</p>
+                <p>- 보유이용기간 (수집 시~위의내용일로부터 6개월)</p>
+                <p>
+                  - 동의를 거부할 권리가 있으며, 동의 거부에 따라
+                  불이익(민원신청 불가) 조치 등 있을 수 있음
+                </p>
+              </div>
+            </div>
+
+            {/* 세 번째 소식 */}
+            <div className='space-y-2'>
+              <p className='font-medium text-gray-800 text-sm'>
+                3. 0000 경로에서 가장 많은 사용자가 유입되었습니다.
+              </p>
+              <div className='text-xs text-gray-600 space-y-1 pl-3'>
+                <p>- 수치 : 이용횟수 (클릭이나 볼륨 만족했을 때 사용량)</p>
+                <p>- 수집내강 개인정보 (본 위의의 작 철때 개인정보)</p>
+                <p>- 보유이용기간 (수집 시~위의내용일로부터 6개월)</p>
+                <p>
+                  - 동의를 거부할 권리가 있으며, 동의 거부에 따라
+                  불이익(민원신청 불가) 조치 등 있을 수 있음
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 닫기 버튼 */}
+        <div className='flex justify-end pt-6'>
+          <Button
+            variant='outline'
+            onClick={() => onOpenChange(false)}
+            className='px-8 py-2 border-gray-300 text-gray-600 hover:bg-gray-50 text-sm rounded-sm'>
+            닫기
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SmartReportModal;


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Style/ServiceDashboard-32` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- [x] 한달 리포트 요약 더보기 페이지 퍼블리싱
- [x] 서비스 대시보드 반응형 추가

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `SmartReportModal.tsx` 컴포넌트 생성 (스마트 리포트 더보기 모달)
- [x] 모달 내 기간 선택 드롭다운 추가 (1개월, 3개월, 6개월, 1년)
- [x] 모달 내 월 선택 기능 구현 (1월~12월)
- [x] `ServiceReport.tsx`에 모달 상태 관리 및 "더보기" 버튼 클릭 이벤트 연결
- [x] `ServiceDashboard.tsx` 반응형 레이아웃 적용
- [x] `StatCardGrid`와 `ServiceReport` 배치 방식 변경 (1024px 이하: 세로 배치, 1024px 이상: 가로 배치)
- [x] `grid-cols-1 lg:grid-cols-[1fr_320px]` 클래스로 반응형 그리드 구현
![image](https://github.com/user-attachments/assets/87f5927c-7964-4098-901e-b8399eddce5a)
<img width="803" alt="image" src="https://github.com/user-attachments/assets/3ecde6b4-0996-407f-9862-cef05013c850" />


<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#32