### PR TITLE
[Style/userdashboard-34]💄Style: 사용자 분석 반응형 스타일 추가 및 대시보드 레이아웃 수정

### DIFF
--- a/src/pages/user-dashboard/UserDashboard.tsx
+++ b/src/pages/user-dashboard/UserDashboard.tsx
@@ -1,11 +1,15 @@
-import RankingUserList from "./components/RankingUserList";
-import UserActivity from "./components/UserActivity";
+import RankingUserList from './components/RankingUserList';
+import UserActivity from './components/UserActivity';
 
 export default function UserDashboard() {
   return (
-    <main className="flex gap-10 items-baseline ">
-      <UserActivity />
-      <RankingUserList />
+    <main className='flex gap-7 items-baseline '>
+      <section className='flex-1 '>
+        <UserActivity />
+      </section>
+      <section className='max-w-95 min-w-72 2xl:min-w-90'>
+        <RankingUserList />
+      </section>
     </main>
-  )
+  );
 }

--- a/src/pages/user-dashboard/components/RankingUserItem.tsx
+++ b/src/pages/user-dashboard/components/RankingUserItem.tsx
@@ -70,7 +70,7 @@ export default function RankingUserItem() {
     },
   ];
   return (
-    <Card className='w-full px-8 space-y-2 h-[calc(100vh-220px)] overflow-y-auto'>
+    <Card className='w-full max-h-170 px-8 space-y-2 h-[calc(100vh-220px)] overflow-y-auto'>
       {rankingData.map((user, index) => {
         const isTop3 = index < 3;
         const rankColor = isTop3

--- a/src/routes/layout/DashboardLayout.tsx
+++ b/src/routes/layout/DashboardLayout.tsx
@@ -8,7 +8,7 @@ const DashboardLayout = () => {
       <Header />
       <main className='relative pt-16 flex'>
         <Sidebar />
-        <div className='flex-1 px-20 py-12'>
+        <div className='flex-1 px-16 py-12'>
           <Outlet />
         </div>
       </main>


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`style/userdashboard-34` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
- 사용자 분석 대시보드 반응형 스타일 추가 및 대시보드 레이아웃 수정

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] `UserDashboard.tsx` & `RankingUserList.tsx`
  - 반응형 스타일 추가

- [x] `DashboardLayout.tsx`
  - 기존: `px-20` -> 변경: `px-16`
  - 시각적으로 과도한 감이 있어 조절했습니다!

<!-- PR에서 중점적으로 봐야할 부분이나 질문 & 애로사항 공유 -->
## 💬 PR 포인트 & 질문사항
- 현재 페이지네이션에서 `previous [] next` 이렇게 되어 있는데  `prev [] next` 로 변경해보면 어떨까요? 시각적으로 좀 더 균형 있어 보일 것 같아서 제안해봅니다~!

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#34 