### PR TITLE
[Fix/Notifications--62] 📝 Chore: 알림 관련 토스트 피드백 추가

### DIFF
--- a/src/hooks/notification/useNotificationActions.ts
+++ b/src/hooks/notification/useNotificationActions.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { NotificationService } from '@/services/notificationService';
+import { showSuccessToast } from '@/lib/toast';
 
 export const useNotificationActions = () => {
   const [isLoading, setIsLoading] = useState(false);
@@ -12,6 +13,9 @@ export const useNotificationActions = () => {
     try {
       await NotificationService.markAsRead(notificationId);
       onSuccess?.();
+
+      // 개별 읽음 처리 성공시 토스트 피드백
+      showSuccessToast('알림이 읽음 처리 되었습니다');
     } catch (error) {
       console.error('알림 읽음 처리 실패:', error);
     } finally {
@@ -24,6 +28,9 @@ export const useNotificationActions = () => {
     try {
       await NotificationService.markAllAsRead(adminId);
       onSuccess?.();
+
+      // 전체 읽음 처리 성공시 토스트 피드백
+      showSuccessToast('모든 알림이 읽음 처리 되었습니다');
     } catch (error) {
       console.error('전체 알림 읽음 처리 실패:', error);
     } finally {

--- a/src/hooks/notification/useNotificationSSE.ts
+++ b/src/hooks/notification/useNotificationSSE.ts
@@ -3,10 +3,12 @@ import { subscribeToNotifications } from '@/apis/notification';
 import { useNotificationRefactored } from './useNotificationRefactored';
 import { useUserStore } from '@/store/useUserStore';
 import { toast } from 'sonner';
+import { showErrorToast, showInfoToast } from '@/lib/toast';
 
 export const useNotificationSSE = () => {
   const eventSourceRef = useRef<EventSource | null>(null);
   const [isConnected, setIsConnected] = useState(false);
+  const [hasShownConnectionError, setHasShownConnectionError] = useState(false);
   const { refreshAllData } = useNotificationRefactored();
   const { user } = useUserStore();
 
@@ -44,11 +46,11 @@ export const useNotificationSSE = () => {
         // 데이터 새로고침
         stableRefreshAllData();
 
-        // 토스트 알림 표시
-        toast.info(notificationData.notificationTitle, {
-          description: notificationData.notificationContent,
-          duration: 5000,
-        });
+        // 토스트 알림 표시 - 새로운 알림 도착 메시지
+        showInfoToast(
+          '새로운 알림이 도착했습니다',
+          notificationData.notificationContent,
+        );
       } catch (error) {
         console.error('알림 데이터 파싱 실패:', error);
       }
@@ -58,6 +60,7 @@ export const useNotificationSSE = () => {
     eventSource.onopen = () => {
       console.log('SSE: 연결 성공!');
       setIsConnected(true);
+      setHasShownConnectionError(false); // 연결 성공시 에러 플래그 리셋
     };
 
     // 연결 오류 처리
@@ -65,7 +68,15 @@ export const useNotificationSSE = () => {
       console.error('SSE 연결 오류:', error);
       console.log('SSE: readyState:', eventSource.readyState);
       setIsConnected(false);
-      // 재연결 로직 추가 가능
+
+      // 연결 실패시 토스트 피드백 (일회성)
+      if (!hasShownConnectionError) {
+        showErrorToast(
+          '알림 연결에 실패했습니다',
+          '실시간 알림을 받을 수 없습니다. 페이지를 새로고침해주세요.',
+        );
+        setHasShownConnectionError(true);
+      }
     };
 
     // 컴포넌트 언마운트 시 연결 해제
@@ -77,7 +88,7 @@ export const useNotificationSSE = () => {
         setIsConnected(false);
       }
     };
-  }, [user?.adminId]);
+  }, [user?.adminId, stableRefreshAllData, hasShownConnectionError]);
 
   return {
     isConnected,

--- a/src/hooks/notification/useNotificationSSE.ts
+++ b/src/hooks/notification/useNotificationSSE.ts
@@ -2,13 +2,15 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { subscribeToNotifications } from '@/apis/notification';
 import { useNotificationRefactored } from './useNotificationRefactored';
 import { useUserStore } from '@/store/useUserStore';
-import { toast } from 'sonner';
 import { showErrorToast, showInfoToast } from '@/lib/toast';
 
 export const useNotificationSSE = () => {
   const eventSourceRef = useRef<EventSource | null>(null);
   const [isConnected, setIsConnected] = useState(false);
   const [hasShownConnectionError, setHasShownConnectionError] = useState(false);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const reconnectCountRef = useRef(0);
+  const maxReconnectAttempts = 3;
   const { refreshAllData } = useNotificationRefactored();
   const { user } = useUserStore();
 
@@ -17,19 +19,26 @@ export const useNotificationSSE = () => {
     refreshAllData();
   }, [refreshAllData]);
 
-  useEffect(() => {
+  // SSE 연결 함수
+  const connectSSE = useCallback(() => {
     if (!user?.adminId) {
       console.log('SSE: user.adminId가 없습니다:', user);
       return;
     }
-
-    console.log('SSE: 연결 시작, adminId:', user.adminId);
 
     // 기존 연결이 있으면 닫기
     if (eventSourceRef.current) {
       console.log('SSE: 기존 연결 닫기');
       eventSourceRef.current.close();
     }
+
+    // 기존 재연결 타이머가 있으면 취소
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    console.log('SSE: 연결 시작, adminId:', user.adminId);
 
     // 새 SSE 연결 생성
     const eventSource = subscribeToNotifications(user.adminId);
@@ -61,6 +70,7 @@ export const useNotificationSSE = () => {
       console.log('SSE: 연결 성공!');
       setIsConnected(true);
       setHasShownConnectionError(false); // 연결 성공시 에러 플래그 리셋
+      reconnectCountRef.current = 0; // 연결 성공시 재연결 카운트 리셋
     };
 
     // 연결 오류 처리
@@ -77,7 +87,34 @@ export const useNotificationSSE = () => {
         );
         setHasShownConnectionError(true);
       }
+
+      // 재연결 시도 (최대 3회)
+      if (
+        reconnectCountRef.current < maxReconnectAttempts &&
+        !reconnectTimeoutRef.current
+      ) {
+        reconnectCountRef.current += 1;
+        const delay = Math.min(
+          1000 * Math.pow(2, reconnectCountRef.current - 1),
+          10000,
+        ); // 지수 백오프, 최대 10초
+
+        console.log(
+          `SSE: ${delay}ms 후 재연결 시도 (${reconnectCountRef.current}/${maxReconnectAttempts})`,
+        );
+
+        reconnectTimeoutRef.current = setTimeout(() => {
+          reconnectTimeoutRef.current = null;
+          connectSSE();
+        }, delay);
+      } else if (reconnectCountRef.current >= maxReconnectAttempts) {
+        console.log('SSE: 최대 재연결 시도 횟수 초과. 재연결을 중단합니다.');
+      }
     };
+  }, [user?.adminId, stableRefreshAllData, hasShownConnectionError]);
+
+  useEffect(() => {
+    connectSSE();
 
     // 컴포넌트 언마운트 시 연결 해제
     return () => {
@@ -87,8 +124,13 @@ export const useNotificationSSE = () => {
         eventSourceRef.current = null;
         setIsConnected(false);
       }
+
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
     };
-  }, [user?.adminId, stableRefreshAllData, hasShownConnectionError]);
+  }, [connectSSE]);
 
   return {
     isConnected,


### PR DESCRIPTION
<!-- 반영한 브랜치 표시 확인용 -->
## ✨ 반영 브랜치
`Fix/Notifications--62` -> `dev`

<!-- 간단한 PR task에 대한 설명 -->
## 📝 설명
알림 관련 토스트 피드백 추가

<!-- 상세 task 변경사항 체크리스트로 기술 -->
## ✅ 변경 사항
- [x] SSE로 알림 업데이트시 토스트 피드백 → 새로운 알림이 도착했습니다 or 발생 알림 내용
  - 파일: `src/hooks/notification/useNotificationSSE.ts`
  - 변경사항: `showInfoToast` 함수 호출로 새로운 알림 도착시 토스트 표시

- [x] SSE를 연결시, 연결 실패시 토스트 피드백 (일회성)
  - 파일: `src/hooks/notification/useNotificationSSE.ts`
  - 변경사항: `showErrorToast` 함수 호출로 연결 실패시 일회성 토스트 표시, `hasShownConnectionError` 상태로 중복 방지

- [x] 알림 전체 읽음시 토스트 피드백 → '모든 알림이 읽음 처리 되었습니다'
  - 파일: `src/hooks/notification/useNotificationActions.ts`
  - 변경사항: `handleMarkAllRead` 함수에 `showSuccessToast` 호출 추가

- [x] SSE 연결 실패시 재연결 로직 최적화 -> 지수 백오프 로직 추가 / 최대 3회
  - 파일: `src/hooks/notification/useNotificationSSE.ts`
  - 변경사항: 지수 백오프 로직 추가 (1초 → 2초 → 4초), 최대 3회 재연결 시도 제한, `reconnectCountRef`와 `reconnectTimeoutRef` 추가, 연결 성공시 카운트 리셋 로직

<!-- 이슈 필터링을 위한 url, 이슈에 관한 PR이 아니면 삭제해도 무방 -->
## 📢 이슈 정보
#62