### PR TITLE
[Feat/service-dashboard-61] ✨ Feature: 서비스 대시보드 기능 구현 및 UI 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.13",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.2",
     "@heroicons/react": "^2.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.13",
     "@radix-ui/react-avatar": "^1.1.10",
@@ -28,7 +29,9 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "gsap": "^3.13.0",
     "lucide-react": "^0.503.0",
+    "motion": "^12.23.12",
     "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-cookie": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-dom": "^19.0.0",
     "react-error-boundary": "^6.0.0",
     "react-router-dom": "^7.5.3",
+    "recharts": "^2.15.4",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^4.1.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@heroicons/react':
+        specifier: ^2.2.0
+        version: 2.2.0(react@19.1.0)
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.13
         version: 1.1.14(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -430,6 +433,11 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@heroicons/react@2.2.0':
+    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
+    peerDependencies:
+      react: '>= 16 || ^19.0.0-rc'
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2574,6 +2582,10 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@heroicons/react@2.2.0(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
 
   '@humanfs/core@0.19.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@gsap/react':
+        specifier: ^2.1.2
+        version: 2.1.2(gsap@3.13.0)(react@19.1.0)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.1.0)
@@ -62,9 +65,15 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.3(@types/react@19.1.2))(@types/react@19.1.2)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      gsap:
+        specifier: ^3.13.0
+        version: 3.13.0
       lucide-react:
         specifier: ^0.503.0
         version: 0.503.0(react@19.1.0)
+      motion:
+        specifier: ^12.23.12
+        version: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -433,6 +442,12 @@ packages:
 
   '@floating-ui/utils@0.2.9':
     resolution: {integrity: sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==}
+
+  '@gsap/react@2.1.2':
+    resolution: {integrity: sha512-JqliybO1837UcgH2hVOM4VO+38APk3ECNrsuSM4MuXp+rbf+/2IG2K1YJiqfTcXQHH7XlA0m3ykniFYstfq0Iw==}
+    peerDependencies:
+      gsap: ^3.12.5
+      react: '>=17'
 
   '@heroicons/react@2.2.0':
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
@@ -1679,6 +1694,20 @@ packages:
     resolution: {integrity: sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==}
     engines: {node: '>= 6'}
 
+  framer-motion@12.23.12:
+    resolution: {integrity: sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1732,6 +1761,9 @@ packages:
 
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
+
+  gsap@3.13.0:
+    resolution: {integrity: sha512-QL7MJ2WMjm1PHWsoFrAQH/J8wUeqZvMtHO58qdekHpCfhvhSL4gSiz6vJf5EeMP0LOn3ZCprL2ki/gjED8ghVw==}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1933,6 +1965,26 @@ packages:
   minimatch@9.0.5:
     resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  motion-dom@12.23.12:
+    resolution: {integrity: sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion@12.23.12:
+    resolution: {integrity: sha512-8jCD8uW5GD1csOoqh1WhH1A6j5APHVE15nuBkFeRiMzYBdRwyAHmSP/oXSuW0WJPZRXTFdBoG4hY9TFWNhhwng==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2582,6 +2634,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   '@floating-ui/utils@0.2.9': {}
+
+  '@gsap/react@2.1.2(gsap@3.13.0)(react@19.1.0)':
+    dependencies:
+      gsap: 3.13.0
+      react: 19.1.0
 
   '@heroicons/react@2.2.0(react@19.1.0)':
     dependencies:
@@ -3834,6 +3891,15 @@ snapshots:
       es-set-tostringtag: 2.1.0
       mime-types: 2.1.35
 
+  framer-motion@12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.23.12
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   fsevents@2.3.3:
     optional: true
 
@@ -3880,6 +3946,8 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
+
+  gsap@3.13.0: {}
 
   has-flag@4.0.0: {}
 
@@ -4034,6 +4102,20 @@ snapshots:
   minimatch@9.0.5:
     dependencies:
       brace-expansion: 2.0.1
+
+  motion-dom@12.23.12:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
+
+  motion@12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      framer-motion: 12.23.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   ms@2.1.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       react-router-dom:
         specifier: ^7.5.3
         version: 7.5.3(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      recharts:
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       sonner:
         specifier: ^2.0.5
         version: 2.0.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -109,7 +112,7 @@ importers:
         version: 4.3.0(rollup@4.40.1)(typescript@5.7.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2))
       zustand:
         specifier: ^5.0.4
-        version: 5.0.4(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
+        version: 5.0.4(@types/react@19.1.2)(immer@10.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@eslint/js':
         specifier: ^9.22.0
@@ -1319,6 +1322,33 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/d3-array@3.2.1':
+    resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.7':
+    resolution: {integrity: sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
 
@@ -1509,6 +1539,50 @@ packages:
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.0:
+    resolution: {integrity: sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@4.4.0:
     resolution: {integrity: sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==}
     engines: {node: '>=6.0'}
@@ -1517,6 +1591,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -1531,6 +1608,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
@@ -1638,8 +1718,15 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.2.2:
+    resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1788,6 +1875,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immer@10.1.3:
+    resolution: {integrity: sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1795,6 +1885,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -1928,6 +2022,13 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
@@ -2009,6 +2110,10 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -2060,6 +2165,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
@@ -2087,6 +2195,9 @@ packages:
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -2129,6 +2240,12 @@ packages:
       react-dom:
         optional: true
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2139,9 +2256,25 @@ packages:
       '@types/react':
         optional: true
 
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2215,6 +2348,9 @@ packages:
   tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.13:
     resolution: {integrity: sha512-mEwzpUgrLySlveBwEVDMKk5B57bhLPYovRfPAXD5gA/98Opn0rCDj3GtLwFvCvH5RK9uPCExUROW5NjDwvqkxw==}
@@ -2300,6 +2436,9 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-plugin-svgr@4.3.0:
     resolution: {integrity: sha512-Jy9qLB2/PyWklpYy0xk0UU3TlU0t2UMpJXZvf+hWII1lAmRHrOUKi11Uw8N3rxoNk7atZNYO3pR3vI1f7oi+6w==}
@@ -3447,6 +3586,30 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.1
 
+  '@types/d3-array@3.2.1': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.7':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.7': {}
 
   '@types/hoist-non-react-statics@3.3.6':
@@ -3678,9 +3841,49 @@ snapshots:
 
   csstype@3.1.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.0: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.0
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@4.4.0:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   deep-is@0.1.4: {}
 
@@ -3689,6 +3892,11 @@ snapshots:
   detect-libc@2.0.4: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.6
+      csstype: 3.1.3
 
   dot-case@3.0.4:
     dependencies:
@@ -3840,7 +4048,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.2.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -3967,12 +4179,17 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immer@10.1.3:
+    optional: true
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
+
+  internmap@2.0.3: {}
 
   is-arrayish@0.2.1: {}
 
@@ -4068,6 +4285,12 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.17.21: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
   lower-case@2.0.2:
     dependencies:
       tslib: 2.8.1
@@ -4135,6 +4358,8 @@ snapshots:
 
   node-releases@2.0.19: {}
 
+  object-assign@4.1.1: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -4183,6 +4408,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   proxy-from-env@1.1.0: {}
 
   punycode@2.3.1: {}
@@ -4207,6 +4438,8 @@ snapshots:
       react: 19.1.0
 
   react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
 
   react-refresh@0.17.0: {}
 
@@ -4244,6 +4477,14 @@ snapshots:
     optionalDependencies:
       react-dom: 19.1.0(react@19.1.0)
 
+  react-smooth@4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      fast-equals: 5.2.2
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-transition-group: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
   react-style-singleton@2.2.3(@types/react@19.1.2)(react@19.1.0):
     dependencies:
       get-nonce: 1.0.1
@@ -4252,7 +4493,33 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.2
 
+  react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   react@19.1.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   resolve-from@4.0.0: {}
 
@@ -4327,6 +4594,8 @@ snapshots:
   tailwindcss@4.1.5: {}
 
   tapable@2.2.1: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.13:
     dependencies:
@@ -4407,6 +4676,23 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.7
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-plugin-svgr@4.3.0(rollup@4.40.1)(typescript@5.7.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.4.2)(lightningcss@1.29.2)):
     dependencies:
       '@rollup/pluginutils': 5.1.4(rollup@4.40.1)
@@ -4442,8 +4728,9 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zustand@5.0.4(@types/react@19.1.2)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+  zustand@5.0.4(@types/react@19.1.2)(immer@10.1.3)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
     optionalDependencies:
       '@types/react': 19.1.2
+      immer: 10.1.3
       react: 19.1.0
       use-sync-external-store: 1.5.0(react@19.1.0)

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,13 +1,13 @@
-import axios from "axios";
+import axios from 'axios';
 import { Cookies } from 'react-cookie';
-import { useAuthStore } from "../store/useAuthStore";
-import { initStatus, refreshAccessTokenAPI } from "./auth";
+import { useAuthStore } from '../store/useAuthStore';
+import { initStatus, refreshAccessTokenAPI } from './auth';
 
-const cookies = new Cookies()
+const cookies = new Cookies();
 
 const axiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
-  headers:{
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8081',
+  headers: {
     'Content-Type': 'application/json',
   },
   withCredentials: true,
@@ -23,29 +23,29 @@ axiosInstance.interceptors.request.use(
   },
   (error) => {
     throw error;
-  }
-)
+  },
+);
 
 // 응답 인터셉터
 axiosInstance.interceptors.response.use(
   (response) => {
     return response;
   },
-  async(error) => {
+  async (error) => {
     const originalRequest = error.config;
 
-    if(error.response?.status === 401 && !originalRequest._retry){
+    if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
 
       const refreshToken = cookies.get('refreshToken');
 
-      if(!refreshToken){
+      if (!refreshToken) {
         console.error('🚨 Refresh Token이 없습니다. 다시 로그인하세요.');
         initStatus();
         window.location.href = '/login';
         throw error;
       }
-      try{
+      try {
         const response = await refreshAccessTokenAPI();
         const newAccessToken = response.accessToken;
 
@@ -53,7 +53,7 @@ axiosInstance.interceptors.response.use(
 
         originalRequest.headers.Authorization = `Bearer ${response.accessToken}`;
         return axiosInstance(originalRequest);
-      }catch(error){
+      } catch (error) {
         console.error('🚨 Refresh Token이 만료되었습니다. 다시 로그인하세요.');
         initStatus();
         window.location.href = '/login';
@@ -62,7 +62,7 @@ axiosInstance.interceptors.response.use(
     } else {
       throw error;
     }
-  }
-)
+  },
+);
 
-export default axiosInstance
+export default axiosInstance;

--- a/src/apis/service-dashboard.ts
+++ b/src/apis/service-dashboard.ts
@@ -1,0 +1,50 @@
+import axiosInstance from './axiosInstance';
+import type {
+  DashboardSummaryResponse,
+  DashboardChartResponse,
+  DashboardAISummaryResponse,
+} from '../types/service-dashboard';
+
+// ===== 서비스 대시보드 API 함수들 =====
+
+/**
+ * 서비스 사용 지표 카드 인덱스 조회
+ * GET /api/admin/dashboard/summary
+ * @returns Promise<DashboardSummaryResponse> - MAU, DAU, 콘텐츠 등록수, 신규 사용자수, 유입 경로 데이터
+ */
+export const getDashboardSummary =
+  async (): Promise<DashboardSummaryResponse> => {
+    console.log('API URL:', axiosInstance.defaults.baseURL);
+    console.log(
+      'Full URL:',
+      `${axiosInstance.defaults.baseURL}/api/admin/dashboard/summary`,
+    );
+    const response = await axiosInstance.get('/api/admin/dashboard/summary');
+    return response.data;
+  };
+
+/**
+ * 서비스 사용 지표 차트 조회(주간)
+ * GET /api/admin/dashboard/chart?typeId={typeId}
+ * @param typeId 차트 타입 ID
+ * @returns Promise<DashboardChartResponse> - 주간 차트 데이터 (날짜별 값)
+ */
+export const getDashboardChart = async (
+  typeId: string,
+): Promise<DashboardChartResponse> => {
+  const response = await axiosInstance.get(
+    `/api/admin/dashboard/chart?typeId=${typeId}`,
+  );
+  return response.data;
+};
+
+/**
+ * 서비스 사용 지표 요약 조회(AI)
+ * GET /api/admin/dashboard/ai-summary
+ * @returns Promise<DashboardAISummaryResponse> - AI가 생성한 서비스 사용 지표 요약
+ */
+export const getDashboardAISummary =
+  async (): Promise<DashboardAISummaryResponse> => {
+    const response = await axiosInstance.get('/api/admin/dashboard/ai-summary');
+    return response.data;
+  };

--- a/src/components/DashboardTitle.tsx
+++ b/src/components/DashboardTitle.tsx
@@ -4,6 +4,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
 
 interface DashboardTitleProps {
   title: string;
@@ -18,9 +19,7 @@ const DashboardTitle = ({ title, tooltipContent }: DashboardTitleProps) => {
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <button className='text-[12px] font-bold text-gray-300 hover:text-gray-400 transition-colors rounded-full py-0.3 px-2 select-none border-2 border-gray-300 hover:border-gray-400 cursor-pointer hover:bg-gray-100 [&_*]:[-webkit-user-drag:none]'>
-                i
-              </button>
+              <InformationCircleIcon className='w-5 h-5 cursor-pointer text-gray-500' />
             </TooltipTrigger>
             <TooltipContent
               side='right'

--- a/src/components/react-bits/CircularText.tsx
+++ b/src/components/react-bits/CircularText.tsx
@@ -1,0 +1,122 @@
+import React, { useEffect } from 'react';
+import { motion, useAnimation, useMotionValue, MotionValue, Transition } from 'motion/react';
+interface CircularTextProps {
+  text: string;
+  spinDuration?: number;
+  onHover?: 'slowDown' | 'speedUp' | 'pause' | 'goBonkers';
+  className?: string;
+}
+
+const getRotationTransition = (duration: number, from: number, loop: boolean = true) => ({
+  from,
+  to: from + 360,
+  ease: 'linear' as const,
+  duration,
+  type: 'tween' as const,
+  repeat: loop ? Infinity : 0
+});
+
+const getTransition = (duration: number, from: number) => ({
+  rotate: getRotationTransition(duration, from),
+  scale: {
+    type: 'spring' as const,
+    damping: 20,
+    stiffness: 300
+  }
+});
+
+const CircularText: React.FC<CircularTextProps> = ({
+  text,
+  spinDuration = 20,
+  onHover = 'speedUp',
+  className = ''
+}) => {
+  const letters = Array.from(text);
+  const controls = useAnimation();
+  const rotation: MotionValue<number> = useMotionValue(0);
+
+  useEffect(() => {
+    const start = rotation.get();
+    controls.start({
+      rotate: start + 360,
+      scale: 1,
+      transition: getTransition(spinDuration, start)
+    });
+  }, [spinDuration, text, onHover, controls]);
+
+  const handleHoverStart = () => {
+    const start = rotation.get();
+
+    if (!onHover) return;
+
+    let transitionConfig: ReturnType<typeof getTransition> | Transition;
+    let scaleVal = 1;
+
+    switch (onHover) {
+      case 'slowDown':
+        transitionConfig = getTransition(spinDuration * 2, start);
+        break;
+      case 'speedUp':
+        transitionConfig = getTransition(spinDuration / 4, start);
+        break;
+      case 'pause':
+        transitionConfig = {
+          rotate: { type: 'spring', damping: 20, stiffness: 300 },
+          scale: { type: 'spring', damping: 20, stiffness: 300 }
+        };
+        break;
+      case 'goBonkers':
+        transitionConfig = getTransition(spinDuration / 20, start);
+        scaleVal = 0.8;
+        break;
+      default:
+        transitionConfig = getTransition(spinDuration, start);
+    }
+
+    controls.start({
+      rotate: start + 360,
+      scale: scaleVal,
+      transition: transitionConfig
+    });
+  };
+
+  const handleHoverEnd = () => {
+    const start = rotation.get();
+    controls.start({
+      rotate: start + 360,
+      scale: 1,
+      transition: getTransition(spinDuration, start)
+    });
+  };
+
+  return (
+    <motion.div
+      className={`m-0 mx-auto rounded-full w-[200px] h-[200px] relative font-black text-white text-center cursor-pointer origin-center ${className}`}
+      style={{ rotate: rotation }}
+      initial={{ rotate: 0 }}
+      animate={controls}
+      onMouseEnter={handleHoverStart}
+      onMouseLeave={handleHoverEnd}
+    >
+      {letters.map((letter, i) => {
+        const rotationDeg = (360 / letters.length) * i;
+        const factor = Math.PI / letters.length;
+        const x = factor * i;
+        const y = factor * i;
+        const transform = `rotateZ(${rotationDeg}deg) translate3d(${x}px, ${y}px, 0)`;
+
+        return (
+          <span
+            key={i}
+            className="absolute inline-block inset-0 text-2xl transition-all duration-500 ease-[cubic-bezier(0,0,0,1)]"
+            style={{ transform, WebkitTransform: transform }}
+          >
+            {letter}
+          </span>
+        );
+      })}
+    </motion.div>
+  );
+};
+
+export default CircularText;

--- a/src/components/react-bits/SplitText.tsx
+++ b/src/components/react-bits/SplitText.tsx
@@ -1,0 +1,207 @@
+import React, { useRef, useEffect, useState } from 'react';
+import { gsap } from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { SplitText as GSAPSplitText } from 'gsap/SplitText';
+import { useGSAP } from '@gsap/react';
+
+gsap.registerPlugin(ScrollTrigger, GSAPSplitText, useGSAP);
+
+export interface SplitTextProps {
+  text: string;
+  className?: string;
+  delay?: number;
+  duration?: number;
+  ease?: string | ((t: number) => number);
+  splitType?: 'chars' | 'words' | 'lines' | 'words, chars';
+  from?: gsap.TweenVars;
+  to?: gsap.TweenVars;
+  threshold?: number;
+  rootMargin?: string;
+  tag?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span';
+  textAlign?: React.CSSProperties['textAlign'];
+  onLetterAnimationComplete?: () => void;
+}
+
+const SplitText: React.FC<SplitTextProps> = ({
+  text,
+  className = '',
+  delay = 100,
+  duration = 0.6,
+  ease = 'power3.out',
+  splitType = 'chars',
+  from = { opacity: 0, y: 40 },
+  to = { opacity: 1, y: 0 },
+  threshold = 0.1,
+  rootMargin = '-100px',
+  tag = 'p',
+  textAlign = 'center',
+  onLetterAnimationComplete
+}) => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const animationCompletedRef = useRef(false);
+  const [fontsLoaded, setFontsLoaded] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (document.fonts.status === 'loaded') {
+      setFontsLoaded(true);
+    } else {
+      document.fonts.ready.then(() => {
+        setFontsLoaded(true);
+      });
+    }
+  }, []);
+
+  useGSAP(
+    () => {
+      if (!ref.current || !text || !fontsLoaded) return;
+      const el = ref.current as HTMLElement & {
+        _rbsplitInstance?: GSAPSplitText;
+      };
+
+      if (el._rbsplitInstance) {
+        try {
+          el._rbsplitInstance.revert();
+        } catch (_) {}
+        el._rbsplitInstance = undefined;
+      }
+
+      const startPct = (1 - threshold) * 100;
+      const marginMatch = /^(-?\d+(?:\.\d+)?)(px|em|rem|%)?$/.exec(rootMargin);
+      const marginValue = marginMatch ? parseFloat(marginMatch[1]) : 0;
+      const marginUnit = marginMatch ? marginMatch[2] || 'px' : 'px';
+      const sign =
+        marginValue === 0
+          ? ''
+          : marginValue < 0
+            ? `-=${Math.abs(marginValue)}${marginUnit}`
+            : `+=${marginValue}${marginUnit}`;
+      const start = `top ${startPct}%${sign}`;
+      let targets: Element[] = [];
+      const assignTargets = (self: GSAPSplitText) => {
+        if (splitType.includes('chars') && (self as GSAPSplitText).chars?.length)
+          targets = (self as GSAPSplitText).chars;
+        if (!targets.length && splitType.includes('words') && self.words.length) targets = self.words;
+        if (!targets.length && splitType.includes('lines') && self.lines.length) targets = self.lines;
+        if (!targets.length) targets = self.chars || self.words || self.lines;
+      };
+      const splitInstance = new GSAPSplitText(el, {
+        type: splitType,
+        smartWrap: true,
+        autoSplit: splitType === 'lines',
+        linesClass: 'split-line',
+        wordsClass: 'split-word',
+        charsClass: 'split-char',
+        reduceWhiteSpace: false,
+        onSplit: (self: GSAPSplitText) => {
+          assignTargets(self);
+          return gsap.fromTo(
+            targets,
+            { ...from },
+            {
+              ...to,
+              duration,
+              ease,
+              stagger: delay / 1000,
+              scrollTrigger: {
+                trigger: el,
+                start,
+                once: true,
+                fastScrollEnd: true,
+                anticipatePin: 0.4
+              },
+              onComplete: () => {
+                animationCompletedRef.current = true;
+                onLetterAnimationComplete?.();
+              },
+              willChange: 'transform, opacity',
+              force3D: true
+            }
+          );
+        }
+      });
+      el._rbsplitInstance = splitInstance;
+      return () => {
+        ScrollTrigger.getAll().forEach(st => {
+          if (st.trigger === el) st.kill();
+        });
+        try {
+          splitInstance.revert();
+        } catch (_) {}
+        el._rbsplitInstance = undefined;
+      };
+    },
+    {
+      dependencies: [
+        text,
+        delay,
+        duration,
+        ease,
+        splitType,
+        JSON.stringify(from),
+        JSON.stringify(to),
+        threshold,
+        rootMargin,
+        fontsLoaded,
+        onLetterAnimationComplete
+      ],
+      scope: ref
+    }
+  );
+
+  const renderTag = () => {
+    const style: React.CSSProperties = {
+      textAlign,
+      wordWrap: 'break-word',
+      willChange: 'transform, opacity'
+    };
+    const classes = `split-parent overflow-hidden inline-block whitespace-normal ${className}`;
+    switch (tag) {
+      case 'h1':
+        return (
+          <h1 ref={ref} style={style} className={classes}>
+            {text}
+          </h1>
+        );
+      case 'h2':
+        return (
+          <h2 ref={ref} style={style} className={classes}>
+            {text}
+          </h2>
+        );
+      case 'h3':
+        return (
+          <h3 ref={ref} style={style} className={classes}>
+            {text}
+          </h3>
+        );
+      case 'h4':
+        return (
+          <h4 ref={ref} style={style} className={classes}>
+            {text}
+          </h4>
+        );
+      case 'h5':
+        return (
+          <h5 ref={ref} style={style} className={classes}>
+            {text}
+          </h5>
+        );
+      case 'h6':
+        return (
+          <h6 ref={ref} style={style} className={classes}>
+            {text}
+          </h6>
+        );
+      default:
+        return (
+          <p ref={ref} style={style} className={classes}>
+            {text}
+          </p>
+        );
+    }
+  };
+
+  return renderTag();
+};
+
+export default SplitText;

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,0 +1,351 @@
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "[&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border flex aspect-video justify-center text-xs [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+  }) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "border-border/50 bg-background grid min-w-[8rem] items-start gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload.map((item, index) => {
+          const key = `${nameKey || item.name || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+          const indicatorColor = color || item.payload.fill || item.color
+
+          return (
+            <div
+              key={item.dataKey}
+              className={cn(
+                "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
+                indicator === "dot" && "items-center"
+              )}
+            >
+              {formatter && item?.value !== undefined && item.name ? (
+                formatter(item.value, item.name, item, index, item.payload)
+              ) : (
+                <>
+                  {itemConfig?.icon ? (
+                    <itemConfig.icon />
+                  ) : (
+                    !hideIndicator && (
+                      <div
+                        className={cn(
+                          "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                          {
+                            "h-2.5 w-2.5": indicator === "dot",
+                            "w-1": indicator === "line",
+                            "w-0 border-[1.5px] border-dashed bg-transparent":
+                              indicator === "dashed",
+                            "my-0.5": nestLabel && indicator === "dashed",
+                          }
+                        )}
+                        style={
+                          {
+                            "--color-bg": indicatorColor,
+                            "--color-border": indicatorColor,
+                          } as React.CSSProperties
+                        }
+                      />
+                    )
+                  )}
+                  <div
+                    className={cn(
+                      "flex flex-1 justify-between leading-none",
+                      nestLabel ? "items-end" : "items-center"
+                    )}
+                  >
+                    <div className="grid gap-1.5">
+                      {nestLabel ? tooltipLabel : null}
+                      <span className="text-muted-foreground">
+                        {itemConfig?.label || item.name}
+                      </span>
+                    </div>
+                    {item.value && (
+                      <span className="text-foreground font-mono font-medium tabular-nums">
+                        {item.value.toLocaleString()}
+                      </span>
+                    )}
+                  </div>
+                </>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean
+    nameKey?: string
+  }) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload.map((item) => {
+        const key = `${nameKey || item.dataKey || "value"}`
+        const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+        return (
+          <div
+            key={item.value}
+            className={cn(
+              "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
+            )}
+          >
+            {itemConfig?.icon && !hideIcon ? (
+              <itemConfig.icon />
+            ) : (
+              <div
+                className="h-2 w-2 shrink-0 rounded-[2px]"
+                style={{
+                  backgroundColor: item.color,
+                }}
+              />
+            )}
+            {itemConfig?.label}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+// Helper to extract item config from a payload.
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,33 +1,51 @@
-"use client"
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { XIcon } from 'lucide-react';
 
-import * as React from "react"
-import * as DialogPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
-
-import { cn } from "@/lib/utils"
+import { cn } from '@/lib/utils';
 
 function Dialog({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+  return (
+    <DialogPrimitive.Root
+      data-slot='dialog'
+      {...props}
+    />
+  );
 }
 
 function DialogTrigger({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+  return (
+    <DialogPrimitive.Trigger
+      data-slot='dialog-trigger'
+      {...props}
+    />
+  );
 }
 
 function DialogPortal({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+  return (
+    <DialogPrimitive.Portal
+      data-slot='dialog-portal'
+      {...props}
+    />
+  );
 }
 
 function DialogClose({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+  return (
+    <DialogPrimitive.Close
+      data-slot='dialog-close'
+      {...props}
+    />
+  );
 }
 
 function DialogOverlay({
@@ -36,14 +54,14 @@ function DialogOverlay({
 }: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
   return (
     <DialogPrimitive.Overlay
-      data-slot="dialog-overlay"
+      data-slot='dialog-overlay'
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
-        className
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
@@ -52,47 +70,46 @@ function DialogContent({
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
-    <DialogPortal data-slot="dialog-portal">
+    <DialogPortal data-slot='dialog-portal'>
       <DialogOverlay />
       <DialogPrimitive.Content
-        data-slot="dialog-content"
+        data-slot='dialog-content'
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
-          className
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          className,
         )}
-        {...props}
-      >
+        {...props}>
         {children}
         <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
           <XIcon />
-          <span className="sr-only">Close</span>
+          <span className='sr-only'>Close</span>
         </DialogPrimitive.Close>
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      data-slot='dialog-header'
+      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
       {...props}
     />
-  )
+  );
 }
 
-function DialogFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
-      data-slot="dialog-footer"
+      data-slot='dialog-footer'
       className={cn(
-        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
-        className
+        'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogTitle({
@@ -101,11 +118,11 @@ function DialogTitle({
 }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
-      data-slot="dialog-title"
-      className={cn("text-lg leading-none font-semibold", className)}
+      data-slot='dialog-title'
+      className={cn('text-lg leading-none font-semibold', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -114,11 +131,11 @@ function DialogDescription({
 }: React.ComponentProps<typeof DialogPrimitive.Description>) {
   return (
     <DialogPrimitive.Description
-      data-slot="dialog-description"
-      className={cn("text-muted-foreground text-sm", className)}
+      data-slot='dialog-description'
+      className={cn('text-muted-foreground text-sm', className)}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -132,4 +149,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/constants/service-dashboard/chart-info.ts
+++ b/src/constants/service-dashboard/chart-info.ts
@@ -1,0 +1,17 @@
+import type { ServiceDashboardType } from '@/types/service-dashboard';
+
+export const chartTitles: Record<ServiceDashboardType, string> = {
+  DAU: '일간 활성 사용자 (DAU)',
+  MAU: '월간 활성 사용자 (MAU)',
+  INFLOW: '신규 사용자',
+  CONTENT: '콘텐츠 등록 수',
+  REFERRAL: '유입 경로 분석',
+};
+
+export const chartDescriptions: Record<ServiceDashboardType, string> = {
+  DAU: '최근 7일간 일간 활성 사용자 추이',
+  MAU: '최근 6개월간 월간 활성 사용자 추이',
+  INFLOW: '최근 7일간 일간 활성 사용자 추이',
+  CONTENT: '최근 6개월간 전체 컨텐츠 등록 수 추이',
+  REFERRAL: '어제 기준 사용자가 유입된 URL의 유입량 추이',
+};

--- a/src/constants/service-dashboard/stat-card.ts
+++ b/src/constants/service-dashboard/stat-card.ts
@@ -47,7 +47,7 @@ export const statCards: StatCardData[] = [
 export const statTitleMap = {
   DAU: '일간 활성 사용자 (DAU)',
   MAU: '월간 활성 사용자 (MAU)',
-  CONTENT: '콘텐츠 수 (3개월)',
+  CONTENT: '콘텐츠 수',
   INFLOW: '신규 사용자',
   REFERRAL: '유입 경로',
 } as const;

--- a/src/constants/service-dashboard/stat-card.ts
+++ b/src/constants/service-dashboard/stat-card.ts
@@ -8,6 +8,7 @@ interface StatCardData {
     value: number;
     isPositive: boolean;
   };
+  unit?: string;
 }
 
 export const statCards: StatCardData[] = [
@@ -24,15 +25,15 @@ export const statCards: StatCardData[] = [
     trend: { value: 10, isPositive: true },
   },
   {
-    title: 'CONTENTS',
+    title: 'CONTENT',
     value: 1000,
-    icon: 'CONTENTS',
+    icon: 'CONTENT',
     trend: { value: 10, isPositive: true },
   },
   {
-    title: 'NEW_USERS',
+    title: 'INFLOW',
     value: 1000,
-    icon: 'NEW_USERS',
+    icon: 'INFLOW',
     trend: { value: 10, isPositive: true },
   },
   {
@@ -46,7 +47,7 @@ export const statCards: StatCardData[] = [
 export const statTitleMap = {
   DAU: '일간 활성 사용자 (DAU)',
   MAU: '월간 활성 사용자 (MAU)',
-  CONTENTS: '콘텐츠 수 (3개월)',
-  NEW_USERS: '신규 사용자',
+  CONTENT: '콘텐츠 수 (3개월)',
+  INFLOW: '신규 사용자',
   REFERRAL: '유입 경로',
 } as const;

--- a/src/constants/service-dashboard/stat-card.ts
+++ b/src/constants/service-dashboard/stat-card.ts
@@ -1,4 +1,16 @@
-export const statCards: StatCardProps[] = [
+import type { ServiceDashboardType } from '@/types/service-dashboard';
+
+interface StatCardData {
+  title: ServiceDashboardType;
+  value: number;
+  icon: ServiceDashboardType;
+  trend: {
+    value: number;
+    isPositive: boolean;
+  };
+}
+
+export const statCards: StatCardData[] = [
   {
     title: 'DAU',
     value: 1000,
@@ -24,9 +36,9 @@ export const statCards: StatCardProps[] = [
     trend: { value: 10, isPositive: true },
   },
   {
-    title: 'REVISIONS',
+    title: 'REFERRAL',
     value: 1000,
-    icon: 'REVISIONS',
+    icon: 'REFERRAL',
     trend: { value: 10, isPositive: true },
   },
 ];
@@ -36,5 +48,5 @@ export const statTitleMap = {
   MAU: '월간 활성 사용자 (MAU)',
   CONTENTS: '콘텐츠 수 (3개월)',
   NEW_USERS: '신규 사용자',
-  REVISIONS: '재방문 사용자',
+  REFERRAL: '유입 경로',
 } as const;

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -1,15 +1,125 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import StatCardGrid from './components/StatCardGrid';
 import ServiceReport from './components/ServiceReport';
 import DashboardTitle from '@/components/DashboardTitle';
 import ServiceChart from './components/ServiceChart';
+import {
+  getDashboardSummary,
+  getDashboardChart,
+  getDashboardAISummary,
+} from '@/apis/service-dashboard';
+import type {
+  IconType,
+  DashboardSummaryResponse,
+  DashboardChartResponse,
+  DashboardAISummaryResponse,
+} from '@/types/service-dashboard';
 
 const ServiceDashboard = () => {
   const [selectedCard, setSelectedCard] = useState<IconType>('DAU');
 
+  // API 데이터 상태 (하위 컴포넌트에서 사용 예정)
+  const [summaryData, setSummaryData] = useState<DashboardSummaryResponse>([]);
+  const [chartData, setChartData] = useState<DashboardChartResponse | null>(
+    null,
+  );
+  const [aiSummaryData, setAiSummaryData] =
+    useState<DashboardAISummaryResponse | null>(null);
+
+  // 현재는 사용하지 않지만 하위 컴포넌트 수정 후 사용 예정
+  console.log('API 데이터:', { summaryData, chartData, aiSummaryData });
+
+  // 로딩 상태
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // API 데이터 로드
+  useEffect(() => {
+    const loadDashboardData = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        // 병렬로 모든 API 호출
+        const [summary, aiSummary] = await Promise.all([
+          getDashboardSummary(),
+          getDashboardAISummary(),
+        ]);
+
+        setSummaryData(summary);
+        setAiSummaryData(aiSummary);
+      } catch (err) {
+        console.error('대시보드 데이터 로드 실패:', err);
+        setError('데이터를 불러오는 중 오류가 발생했습니다.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadDashboardData();
+  }, []);
+
+  // 선택된 카드에 따른 차트 데이터 로드
+  useEffect(() => {
+    const loadChartData = async () => {
+      if (!selectedCard) return;
+
+      try {
+        // IconType을 typeId로 매핑
+        const typeIdMap: Record<IconType, string> = {
+          DAU: 'dau',
+          MAU: 'mau',
+          CONTENTS: 'contents',
+          NEW_USERS: 'new_users',
+          REVISIONS: 'revisions',
+        };
+
+        const typeId = typeIdMap[selectedCard];
+        if (typeId) {
+          const chart = await getDashboardChart(typeId);
+          setChartData(chart);
+        }
+      } catch (err) {
+        console.error('차트 데이터 로드 실패:', err);
+      }
+    };
+
+    loadChartData();
+  }, [selectedCard]);
+
   const handleCardSelect = (cardTitle: IconType) => {
     setSelectedCard(cardTitle);
   };
+
+  // 로딩 상태 처리
+  if (isLoading) {
+    return (
+      <section>
+        <DashboardTitle
+          title='서비스 대시보드'
+          tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
+        />
+        <div className='flex items-center justify-center h-64'>
+          <div className='text-lg text-gray-500'>데이터를 불러오는 중...</div>
+        </div>
+      </section>
+    );
+  }
+
+  // 에러 상태 처리
+  if (error) {
+    return (
+      <section>
+        <DashboardTitle
+          title='서비스 대시보드'
+          tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
+        />
+        <div className='flex items-center justify-center h-64'>
+          <div className='text-lg text-red-500'>{error}</div>
+        </div>
+      </section>
+    );
+  }
 
   return (
     <section>
@@ -22,7 +132,7 @@ const ServiceDashboard = () => {
           selectedCard={selectedCard}
           onCardSelect={handleCardSelect}
         />
-        <ServiceReport />
+        <ServiceReport data={aiSummaryData} />
       </div>
       <DashboardTitle
         title='일간 사용자 활성 지표'

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -3,20 +3,22 @@ import StatCardGrid from './components/StatCardGrid';
 import ServiceReport from './components/ServiceReport';
 import DashboardTitle from '@/components/DashboardTitle';
 import ServiceChart from './components/ServiceChart';
+import SplitText from '@/components/react-bits/SplitText';
+import CircularText from '@/components/react-bits/CircularText';
 import {
   getDashboardSummary,
   getDashboardChart,
   getDashboardAISummary,
 } from '@/apis/service-dashboard';
 import type {
-  IconType,
+  ServiceDashboardType,
   DashboardSummaryResponse,
   DashboardChartResponse,
   DashboardAISummaryResponse,
 } from '@/types/service-dashboard';
 
 const ServiceDashboard = () => {
-  const [selectedCard, setSelectedCard] = useState<IconType>('DAU');
+  const [selectedCard, setSelectedCard] = useState<ServiceDashboardType>('DAU');
 
   // API 데이터 상태 (하위 컴포넌트에서 사용 예정)
   const [summaryData, setSummaryData] = useState<DashboardSummaryResponse>([]);
@@ -65,20 +67,8 @@ const ServiceDashboard = () => {
       if (!selectedCard) return;
 
       try {
-        // IconType을 typeId로 매핑
-        const typeIdMap: Record<IconType, string> = {
-          DAU: 'dau',
-          MAU: 'mau',
-          CONTENTS: 'contents',
-          NEW_USERS: 'new_users',
-          REVISIONS: 'revisions',
-        };
-
-        const typeId = typeIdMap[selectedCard];
-        if (typeId) {
-          const chart = await getDashboardChart(typeId);
-          setChartData(chart);
-        }
+        const chart = await getDashboardChart(selectedCard);
+        setChartData(chart);
       } catch (err) {
         console.error('차트 데이터 로드 실패:', err);
       }
@@ -87,7 +77,7 @@ const ServiceDashboard = () => {
     loadChartData();
   }, [selectedCard]);
 
-  const handleCardSelect = (cardTitle: IconType) => {
+  const handleCardSelect = (cardTitle: ServiceDashboardType) => {
     setSelectedCard(cardTitle);
   };
 
@@ -99,8 +89,21 @@ const ServiceDashboard = () => {
           title='서비스 대시보드'
           tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
         />
-        <div className='flex items-center justify-center h-64'>
-          <div className='text-lg text-gray-500'>데이터를 불러오는 중...</div>
+        <div className='flex flex-col items-center justify-center h-96 space-y-8'>
+          <CircularText
+            text='LOADING'
+            spinDuration={3}
+            className='w-32 h-32'
+          />
+          <SplitText
+            text='데이터를 불러오는 중...'
+            className='text-lg text-gray-500'
+            tag='p'
+            delay={50}
+            duration={0.8}
+            from={{ opacity: 0, y: 20 }}
+            to={{ opacity: 1, y: 0 }}
+          />
         </div>
       </section>
     );
@@ -131,6 +134,7 @@ const ServiceDashboard = () => {
         <StatCardGrid
           selectedCard={selectedCard}
           onCardSelect={handleCardSelect}
+          data={summaryData}
         />
         <ServiceReport data={aiSummaryData} />
       </div>

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -139,7 +139,7 @@ const ServiceDashboard = () => {
         <ServiceReport data={aiSummaryData} />
       </div>
       <DashboardTitle
-        title='일간 사용자 활성 지표'
+        title='상세 지표 차트'
         tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
       />
       <ServiceChart

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -130,7 +130,7 @@ const ServiceDashboard = () => {
         title='서비스 대시보드'
         tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
       />
-      <div className='grid grid-cols-1 lg:grid-cols-[1fr_320px] gap-6 mb-12'>
+      <div className='grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-6 mb-12'>
         <StatCardGrid
           selectedCard={selectedCard}
           onCardSelect={handleCardSelect}

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -115,7 +115,7 @@ const ServiceDashboard = () => {
       <section>
         <DashboardTitle
           title='서비스 대시보드'
-          tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
+          tooltipContent='해당 지표는 어제를 기준으로 하는 데이터입니다.'
         />
         <div className='flex items-center justify-center h-64'>
           <div className='text-lg text-red-500'>{error}</div>
@@ -128,7 +128,7 @@ const ServiceDashboard = () => {
     <section>
       <DashboardTitle
         title='서비스 대시보드'
-        tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
+        tooltipContent='해당 지표는 어제를 기준으로 하는 데이터입니다.'
       />
       <div className='grid grid-cols-1 xl:grid-cols-[1fr_320px] gap-6 mb-12'>
         <StatCardGrid

--- a/src/pages/service-dashboard/ServiceDashboard.tsx
+++ b/src/pages/service-dashboard/ServiceDashboard.tsx
@@ -142,7 +142,10 @@ const ServiceDashboard = () => {
         title='일간 사용자 활성 지표'
         tooltipContent='서비스의 주요 지표와 통계를 한눈에 확인할 수 있는 대시보드입니다.'
       />
-      <ServiceChart />
+      <ServiceChart
+        selectedCard={selectedCard}
+        data={chartData}
+      />
     </section>
   );
 };

--- a/src/pages/service-dashboard/components/ChartEmptyState.tsx
+++ b/src/pages/service-dashboard/components/ChartEmptyState.tsx
@@ -1,0 +1,30 @@
+interface ChartEmptyStateProps {
+  message: string;
+  showDots?: boolean;
+}
+
+const ChartEmptyState = ({
+  message,
+  showDots = true,
+}: ChartEmptyStateProps) => {
+  return (
+    <div className='flex flex-col items-center justify-center h-64 space-y-4'>
+      <p className='text-lg text-blue-500 font-medium animate-pulse'>
+        {message}
+      </p>
+      {showDots && (
+        <div className='flex space-x-1'>
+          <div className='w-2 h-2 bg-blue-500 rounded-full animate-bounce'></div>
+          <div
+            className='w-2 h-2 bg-blue-500 rounded-full animate-bounce'
+            style={{ animationDelay: '0.1s' }}></div>
+          <div
+            className='w-2 h-2 bg-blue-500 rounded-full animate-bounce'
+            style={{ animationDelay: '0.2s' }}></div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ChartEmptyState;

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -6,10 +6,14 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
-import type { DashboardChartResponse } from '@/types/service-dashboard';
+import type {
+  DashboardChartResponse,
+  ServiceDashboardType,
+} from '@/types/service-dashboard';
 
 interface LineChartProps {
   data: DashboardChartResponse;
+  chartType?: ServiceDashboardType;
 }
 
 const chartConfig = {
@@ -19,7 +23,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function ServiceLineChart({ data }: LineChartProps) {
+export function ServiceLineChart({ data, chartType }: LineChartProps) {
   // API 데이터를 차트 형식으로 변환
   const chartData = data.map((item) => ({
     date: item.xlabels,
@@ -46,7 +50,12 @@ export function ServiceLineChart({ data }: LineChartProps) {
           tickMargin={8}
           tickFormatter={(value) => {
             const date = new Date(value);
-            return `${date.getMonth() + 1}/${date.getDate()}`;
+            // MAU와 CONTENT는 월 단위, DAU와 INFLOW는 일 단위
+            if (chartType === 'MAU' || chartType === 'CONTENT') {
+              return `${date.getMonth() + 1}월`;
+            } else {
+              return `${date.getMonth() + 1}/${date.getDate()}`;
+            }
           }}
         />
         <ChartTooltip

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -1,13 +1,9 @@
-'use client';
-
-import { TrendingUp } from 'lucide-react';
 import { CartesianGrid, LabelList, Line, LineChart, XAxis } from 'recharts';
 
 import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -159,14 +155,6 @@ export function ServiceLineChart({ type, data }: LineChartProps) {
           </LineChart>
         </ChartContainer>
       </CardContent>
-      <CardFooter className='flex-col items-start gap-2 text-sm'>
-        <div className='flex gap-2 leading-none font-medium'>
-          최근 7일간 데이터 <TrendingUp className='h-4 w-4' />
-        </div>
-        <div className='text-muted-foreground leading-none'>
-          {chartData.length}일간의 {getTitle(type)} 추이를 보여줍니다
-        </div>
-      </CardFooter>
     </Card>
   );
 }

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -1,27 +1,15 @@
 import { CartesianGrid, LabelList, Line, LineChart, XAxis } from 'recharts';
 
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
   ChartConfig,
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
-import ChartEmptyState from './ChartEmptyState';
-import type {
-  ServiceDashboardType,
-  DashboardChartResponse,
-} from '@/types/service-dashboard';
+import type { DashboardChartResponse } from '@/types/service-dashboard';
 
 interface LineChartProps {
-  type: ServiceDashboardType;
-  data: DashboardChartResponse | null;
+  data: DashboardChartResponse;
 }
 
 const chartConfig = {
@@ -31,132 +19,59 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function ServiceLineChart({ type, data }: LineChartProps) {
+export function ServiceLineChart({ data }: LineChartProps) {
   // API 데이터를 차트 형식으로 변환
-  const chartData =
-    data?.map((item) => ({
-      date: item.xlabels,
-      value: item.value ? parseInt(item.value) : 0,
-    })) || [];
-
-  const getTitle = (type: ServiceDashboardType) => {
-    switch (type) {
-      case 'DAU':
-        return '일간 활성 사용자 (DAU)';
-      case 'MAU':
-        return '월간 활성 사용자 (MAU)';
-      case 'INFLOW':
-        return '신규 사용자';
-      case 'CONTENT':
-        return '콘텐츠 등록 수';
-      default:
-        return '사용자 지표';
-    }
-  };
-
-  const getDescription = (type: ServiceDashboardType) => {
-    switch (type) {
-      case 'DAU':
-        return '최근 7일간 일간 활성 사용자 추이';
-      case 'MAU':
-        return '최근 7일간 월간 활성 사용자 추이';
-      case 'INFLOW':
-        return '최근 7일간 신규 사용자 추이';
-      case 'CONTENT':
-        return '최근 7일간 콘텐츠 등록 수 추이';
-      default:
-        return '최근 7일간 사용자 지표 추이';
-    }
-  };
-
-  // 데이터가 없거나 빈 배열인 경우
-  if (!data || chartData.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{getTitle(type)}</CardTitle>
-          <CardDescription>{getDescription(type)}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ChartEmptyState message='데이터 집계중인 항목입니다.' />
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // value가 null인 경우 (분석된 결과가 없는 경우)
-  const hasNullValues = data.some((item) => item.value === null);
-  if (hasNullValues) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle>{getTitle(type)}</CardTitle>
-          <CardDescription>{getDescription(type)}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <ChartEmptyState
-            message='분석된 결과가 없습니다.'
-            showDots={false}
-          />
-        </CardContent>
-      </Card>
-    );
-  }
+  const chartData = data.map((item) => ({
+    date: item.xlabels,
+    value: item.value ? parseInt(item.value) : 0,
+  }));
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>{getTitle(type)}</CardTitle>
-        <CardDescription>{getDescription(type)}</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <ChartContainer
-          config={chartConfig}
-          className='max-h-[400px] mx-auto'>
-          <LineChart
-            accessibilityLayer
-            data={chartData}
-            margin={{
-              top: 20,
-              left: 12,
-              right: 12,
-            }}>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey='date'
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              tickFormatter={(value) => {
-                const date = new Date(value);
-                return `${date.getMonth() + 1}/${date.getDate()}`;
-              }}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator='line' />}
-            />
-            <Line
-              dataKey='value'
-              type='natural'
-              stroke='var(--color-value)'
-              strokeWidth={2}
-              dot={{
-                fill: 'var(--color-value)',
-              }}
-              activeDot={{
-                r: 6,
-              }}>
-              <LabelList
-                position='top'
-                offset={12}
-                className='fill-foreground'
-                fontSize={12}
-              />
-            </Line>
-          </LineChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+    <ChartContainer
+      config={chartConfig}
+      className='max-h-[400px] mx-auto'>
+      <LineChart
+        accessibilityLayer
+        data={chartData}
+        margin={{
+          top: 20,
+          left: 12,
+          right: 12,
+        }}>
+        <CartesianGrid vertical={false} />
+        <XAxis
+          dataKey='date'
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          tickFormatter={(value) => {
+            const date = new Date(value);
+            return `${date.getMonth() + 1}/${date.getDate()}`;
+          }}
+        />
+        <ChartTooltip
+          cursor={false}
+          content={<ChartTooltipContent indicator='line' />}
+        />
+        <Line
+          dataKey='value'
+          type='natural'
+          stroke='var(--color-value)'
+          strokeWidth={2}
+          dot={{
+            fill: 'var(--color-value)',
+          }}
+          activeDot={{
+            r: 6,
+          }}>
+          <LabelList
+            position='top'
+            offset={12}
+            className='fill-foreground'
+            fontSize={12}
+          />
+        </Line>
+      </LineChart>
+    </ChartContainer>
   );
 }

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -17,6 +17,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
+import ChartEmptyState from './ChartEmptyState';
 import type {
   ServiceDashboardType,
   DashboardChartResponse,
@@ -39,7 +40,7 @@ export function ServiceLineChart({ type, data }: LineChartProps) {
   const chartData =
     data?.map((item) => ({
       date: item.xlabels,
-      value: parseInt(item.value),
+      value: item.value ? parseInt(item.value) : 0,
     })) || [];
 
   const getTitle = (type: ServiceDashboardType) => {
@@ -72,6 +73,7 @@ export function ServiceLineChart({ type, data }: LineChartProps) {
     }
   };
 
+  // 데이터가 없거나 빈 배열인 경우
   if (!data || chartData.length === 0) {
     return (
       <Card>
@@ -80,9 +82,26 @@ export function ServiceLineChart({ type, data }: LineChartProps) {
           <CardDescription>{getDescription(type)}</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className='flex items-center justify-center h-64 text-gray-500'>
-            데이터가 없습니다.
-          </div>
+          <ChartEmptyState message='데이터 집계중인 항목입니다.' />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // value가 null인 경우 (분석된 결과가 없는 경우)
+  const hasNullValues = data.some((item) => item.value === null);
+  if (hasNullValues) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{getTitle(type)}</CardTitle>
+          <CardDescription>{getDescription(type)}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartEmptyState
+            message='분석된 결과가 없습니다.'
+            showDots={false}
+          />
         </CardContent>
       </Card>
     );

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { TrendingUp } from 'lucide-react';
+import { CartesianGrid, LabelList, Line, LineChart, XAxis } from 'recharts';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import type {
+  ServiceDashboardType,
+  DashboardChartResponse,
+} from '@/types/service-dashboard';
+
+interface LineChartProps {
+  type: ServiceDashboardType;
+  data: DashboardChartResponse | null;
+}
+
+const chartConfig = {
+  value: {
+    label: '사용자 수',
+    color: 'var(--chart-1)',
+  },
+} satisfies ChartConfig;
+
+export function ServiceLineChart({ type, data }: LineChartProps) {
+  // API 데이터를 차트 형식으로 변환
+  const chartData =
+    data?.map((item) => ({
+      date: item.xlabels,
+      value: parseInt(item.value),
+    })) || [];
+
+  const getTitle = (type: ServiceDashboardType) => {
+    switch (type) {
+      case 'DAU':
+        return '일간 활성 사용자 (DAU)';
+      case 'MAU':
+        return '월간 활성 사용자 (MAU)';
+      case 'INFLOW':
+        return '신규 사용자';
+      case 'CONTENT':
+        return '콘텐츠 등록 수';
+      default:
+        return '사용자 지표';
+    }
+  };
+
+  const getDescription = (type: ServiceDashboardType) => {
+    switch (type) {
+      case 'DAU':
+        return '최근 7일간 일간 활성 사용자 추이';
+      case 'MAU':
+        return '최근 7일간 월간 활성 사용자 추이';
+      case 'INFLOW':
+        return '최근 7일간 신규 사용자 추이';
+      case 'CONTENT':
+        return '최근 7일간 콘텐츠 등록 수 추이';
+      default:
+        return '최근 7일간 사용자 지표 추이';
+    }
+  };
+
+  if (!data || chartData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{getTitle(type)}</CardTitle>
+          <CardDescription>{getDescription(type)}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className='flex items-center justify-center h-64 text-gray-500'>
+            데이터가 없습니다.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{getTitle(type)}</CardTitle>
+        <CardDescription>{getDescription(type)}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig}>
+          <LineChart
+            accessibilityLayer
+            data={chartData}
+            margin={{
+              top: 20,
+              left: 12,
+              right: 12,
+            }}>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey='date'
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tickFormatter={(value) => {
+                const date = new Date(value);
+                return `${date.getMonth() + 1}/${date.getDate()}`;
+              }}
+            />
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent indicator='line' />}
+            />
+            <Line
+              dataKey='value'
+              type='natural'
+              stroke='var(--color-value)'
+              strokeWidth={2}
+              dot={{
+                fill: 'var(--color-value)',
+              }}
+              activeDot={{
+                r: 6,
+              }}>
+              <LabelList
+                position='top'
+                offset={12}
+                className='fill-foreground'
+                fontSize={12}
+              />
+            </Line>
+          </LineChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col items-start gap-2 text-sm'>
+        <div className='flex gap-2 leading-none font-medium'>
+          최근 7일간 데이터 <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          {chartData.length}일간의 {getTitle(type)} 추이를 보여줍니다
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/pages/service-dashboard/components/LineChart.tsx
+++ b/src/pages/service-dashboard/components/LineChart.tsx
@@ -110,7 +110,9 @@ export function ServiceLineChart({ type, data }: LineChartProps) {
         <CardDescription>{getDescription(type)}</CardDescription>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig}>
+        <ChartContainer
+          config={chartConfig}
+          className='max-h-[400px] mx-auto'>
           <LineChart
             accessibilityLayer
             data={chartData}

--- a/src/pages/service-dashboard/components/PieChart.tsx
+++ b/src/pages/service-dashboard/components/PieChart.tsx
@@ -2,6 +2,7 @@
 
 import { TrendingUp } from 'lucide-react';
 import { LabelList, Pie, PieChart } from 'recharts';
+import { ReactNode } from 'react';
 
 import {
   Card,
@@ -17,6 +18,7 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
+import ChartEmptyState from './ChartEmptyState';
 import type {
   ServiceDashboardType,
   DashboardChartResponse,
@@ -49,11 +51,11 @@ const chartConfig = {
   },
 } satisfies ChartConfig;
 
-export function ServicePieChart({ type, data }: PieChartProps) {
+export function ServicePieChart({ data }: PieChartProps) {
   // API 데이터를 차트 형식으로 변환
   const chartData =
     data?.map((item, index) => {
-      const value = parseInt(item.value);
+      const value = item.value ? parseInt(item.value) : 0;
       const source = item.xlabels || `소스 ${index + 1}`;
 
       // 소스명을 간단하게 변환
@@ -75,6 +77,7 @@ export function ServicePieChart({ type, data }: PieChartProps) {
       };
     }) || [];
 
+  // 데이터가 없거나 빈 배열인 경우
   if (!data || chartData.length === 0) {
     return (
       <Card className='flex flex-col'>
@@ -83,9 +86,26 @@ export function ServicePieChart({ type, data }: PieChartProps) {
           <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
         </CardHeader>
         <CardContent className='flex-1 pb-0'>
-          <div className='flex items-center justify-center h-64 text-gray-500'>
-            데이터가 없습니다.
-          </div>
+          <ChartEmptyState message='데이터 집계중인 항목입니다.' />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // value가 null인 경우 (분석된 결과가 없는 경우)
+  const hasNullValues = data.some((item) => item.value === null);
+  if (hasNullValues) {
+    return (
+      <Card className='flex flex-col'>
+        <CardHeader className='items-center pb-0'>
+          <CardTitle>유입 경로 분석</CardTitle>
+          <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
+        </CardHeader>
+        <CardContent className='flex-1 pb-0'>
+          <ChartEmptyState
+            message='분석된 결과가 없습니다.'
+            showDots={false}
+          />
         </CardContent>
       </Card>
     );
@@ -118,8 +138,8 @@ export function ServicePieChart({ type, data }: PieChartProps) {
                 className='fill-background'
                 stroke='none'
                 fontSize={12}
-                formatter={(value: keyof typeof chartConfig) =>
-                  chartConfig[value]?.label || value
+                formatter={(value: ReactNode) =>
+                  chartConfig[value as keyof typeof chartConfig]?.label || value
                 }
               />
             </Pie>

--- a/src/pages/service-dashboard/components/PieChart.tsx
+++ b/src/pages/service-dashboard/components/PieChart.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { TrendingUp } from 'lucide-react';
 import { LabelList, Pie, PieChart } from 'recharts';
 import { ReactNode } from 'react';

--- a/src/pages/service-dashboard/components/PieChart.tsx
+++ b/src/pages/service-dashboard/components/PieChart.tsx
@@ -2,29 +2,17 @@ import { TrendingUp } from 'lucide-react';
 import { LabelList, Pie, PieChart } from 'recharts';
 import { ReactNode } from 'react';
 
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { CardFooter } from '@/components/ui/card';
 import {
   ChartConfig,
   ChartContainer,
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
-import ChartEmptyState from './ChartEmptyState';
-import type {
-  ServiceDashboardType,
-  DashboardChartResponse,
-} from '@/types/service-dashboard';
+import type { DashboardChartResponse } from '@/types/service-dashboard';
 
 interface PieChartProps {
-  type: ServiceDashboardType;
-  data: DashboardChartResponse | null;
+  data: DashboardChartResponse;
 }
 
 const chartConfig = {
@@ -51,99 +39,58 @@ const chartConfig = {
 
 export function ServicePieChart({ data }: PieChartProps) {
   // API 데이터를 차트 형식으로 변환
-  const chartData =
-    data?.map((item, index) => {
-      const value = item.value ? parseInt(item.value) : 0;
-      const source = item.xlabels || `소스 ${index + 1}`;
+  const chartData = data.map((item, index) => {
+    const value = item.value ? parseInt(item.value) : 0;
+    const source = item.xlabels || `소스 ${index + 1}`;
 
-      // 소스명을 간단하게 변환
-      let label = source;
-      if (source.includes('naver.com')) {
-        label = 'naver';
-      } else if (source.includes('google.com')) {
-        label = 'google';
-      } else if (source.includes('direct') || source === '직접') {
-        label = 'direct';
-      } else {
-        label = 'other';
-      }
+    // 소스명을 간단하게 변환
+    let label = source;
+    if (source.includes('naver.com')) {
+      label = 'naver';
+    } else if (source.includes('google.com')) {
+      label = 'google';
+    } else if (source.includes('direct') || source === '직접') {
+      label = 'direct';
+    } else {
+      label = 'other';
+    }
 
-      return {
-        source: label,
-        value: value,
-        fill: `var(--color-${label})`,
-      };
-    }) || [];
-
-  // 데이터가 없거나 빈 배열인 경우
-  if (!data || chartData.length === 0) {
-    return (
-      <Card className='flex flex-col'>
-        <CardHeader className='items-center pb-0'>
-          <CardTitle>유입 경로 분석</CardTitle>
-          <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
-        </CardHeader>
-        <CardContent className='flex-1 pb-0'>
-          <ChartEmptyState message='데이터 집계중인 항목입니다.' />
-        </CardContent>
-      </Card>
-    );
-  }
-
-  // value가 null인 경우 (분석된 결과가 없는 경우)
-  const hasNullValues = data.some((item) => item.value === null);
-  if (hasNullValues) {
-    return (
-      <Card className='flex flex-col'>
-        <CardHeader className='items-center pb-0'>
-          <CardTitle>유입 경로 분석</CardTitle>
-          <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
-        </CardHeader>
-        <CardContent className='flex-1 pb-0'>
-          <ChartEmptyState
-            message='분석된 결과가 없습니다.'
-            showDots={false}
-          />
-        </CardContent>
-      </Card>
-    );
-  }
+    return {
+      source: label,
+      value: value,
+      fill: `var(--color-${label})`,
+    };
+  });
 
   return (
-    <Card className='flex flex-col'>
-      <CardHeader className='items-center pb-0'>
-        <CardTitle>유입 경로 분석</CardTitle>
-        <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
-      </CardHeader>
-      <CardContent className='flex-1 pb-0'>
-        <ChartContainer
-          config={chartConfig}
-          className='[&_.recharts-text]:fill-background mx-auto aspect-square max-h-[250px]'>
-          <PieChart>
-            <ChartTooltip
-              content={
-                <ChartTooltipContent
-                  nameKey='value'
-                  hideLabel
-                />
+    <>
+      <ChartContainer
+        config={chartConfig}
+        className='[&_.recharts-text]:fill-background mx-auto aspect-square max-h-[250px]'>
+        <PieChart>
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                nameKey='value'
+                hideLabel
+              />
+            }
+          />
+          <Pie
+            data={chartData}
+            dataKey='value'>
+            <LabelList
+              dataKey='source'
+              className='fill-background'
+              stroke='none'
+              fontSize={12}
+              formatter={(value: ReactNode) =>
+                chartConfig[value as keyof typeof chartConfig]?.label || value
               }
             />
-            <Pie
-              data={chartData}
-              dataKey='value'>
-              <LabelList
-                dataKey='source'
-                className='fill-background'
-                stroke='none'
-                fontSize={12}
-                formatter={(value: ReactNode) =>
-                  chartConfig[value as keyof typeof chartConfig]?.label || value
-                }
-              />
-            </Pie>
-          </PieChart>
-        </ChartContainer>
-      </CardContent>
+          </Pie>
+        </PieChart>
+      </ChartContainer>
       <CardFooter className='flex-col gap-2 text-sm'>
         <div className='flex items-center gap-2 leading-none font-medium'>
           유입 경로 분석 <TrendingUp className='h-4 w-4' />
@@ -152,6 +99,6 @@ export function ServicePieChart({ data }: PieChartProps) {
           {chartData.length}개 경로의 사용자 유입 분포를 보여줍니다
         </div>
       </CardFooter>
-    </Card>
+    </>
   );
 }

--- a/src/pages/service-dashboard/components/PieChart.tsx
+++ b/src/pages/service-dashboard/components/PieChart.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { TrendingUp } from 'lucide-react';
+import { LabelList, Pie, PieChart } from 'recharts';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import type {
+  ServiceDashboardType,
+  DashboardChartResponse,
+} from '@/types/service-dashboard';
+
+interface PieChartProps {
+  type: ServiceDashboardType;
+  data: DashboardChartResponse | null;
+}
+
+const chartConfig = {
+  value: {
+    label: '사용자 수',
+  },
+  naver: {
+    label: '네이버',
+    color: 'var(--chart-1)',
+  },
+  google: {
+    label: '구글',
+    color: 'var(--chart-2)',
+  },
+  direct: {
+    label: '직접 접속',
+    color: 'var(--chart-3)',
+  },
+  other: {
+    label: '기타',
+    color: 'var(--chart-4)',
+  },
+} satisfies ChartConfig;
+
+export function ServicePieChart({ type, data }: PieChartProps) {
+  // API 데이터를 차트 형식으로 변환
+  const chartData =
+    data?.map((item, index) => {
+      const value = parseInt(item.value);
+      const source = item.xlabels || `소스 ${index + 1}`;
+
+      // 소스명을 간단하게 변환
+      let label = source;
+      if (source.includes('naver.com')) {
+        label = 'naver';
+      } else if (source.includes('google.com')) {
+        label = 'google';
+      } else if (source.includes('direct') || source === '직접') {
+        label = 'direct';
+      } else {
+        label = 'other';
+      }
+
+      return {
+        source: label,
+        value: value,
+        fill: `var(--color-${label})`,
+      };
+    }) || [];
+
+  if (!data || chartData.length === 0) {
+    return (
+      <Card className='flex flex-col'>
+        <CardHeader className='items-center pb-0'>
+          <CardTitle>유입 경로 분석</CardTitle>
+          <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
+        </CardHeader>
+        <CardContent className='flex-1 pb-0'>
+          <div className='flex items-center justify-center h-64 text-gray-500'>
+            데이터가 없습니다.
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className='flex flex-col'>
+      <CardHeader className='items-center pb-0'>
+        <CardTitle>유입 경로 분석</CardTitle>
+        <CardDescription>최근 7일간 유입 경로별 사용자 분포</CardDescription>
+      </CardHeader>
+      <CardContent className='flex-1 pb-0'>
+        <ChartContainer
+          config={chartConfig}
+          className='[&_.recharts-text]:fill-background mx-auto aspect-square max-h-[250px]'>
+          <PieChart>
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  nameKey='value'
+                  hideLabel
+                />
+              }
+            />
+            <Pie
+              data={chartData}
+              dataKey='value'>
+              <LabelList
+                dataKey='source'
+                className='fill-background'
+                stroke='none'
+                fontSize={12}
+                formatter={(value: keyof typeof chartConfig) =>
+                  chartConfig[value]?.label || value
+                }
+              />
+            </Pie>
+          </PieChart>
+        </ChartContainer>
+      </CardContent>
+      <CardFooter className='flex-col gap-2 text-sm'>
+        <div className='flex items-center gap-2 leading-none font-medium'>
+          유입 경로 분석 <TrendingUp className='h-4 w-4' />
+        </div>
+        <div className='text-muted-foreground leading-none'>
+          {chartData.length}개 경로의 사용자 유입 분포를 보여줍니다
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/pages/service-dashboard/components/ServiceChart.tsx
+++ b/src/pages/service-dashboard/components/ServiceChart.tsx
@@ -1,3 +1,15 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  chartTitles,
+  chartDescriptions,
+} from '@/constants/service-dashboard/chart-info';
+import ChartEmptyState from './ChartEmptyState';
 import { ServiceLineChart } from './LineChart';
 import { ServicePieChart } from './PieChart';
 import type {
@@ -11,21 +23,65 @@ interface ServiceChartProps {
 }
 
 const ServiceChart = ({ selectedCard, data }: ServiceChartProps) => {
+  // 데이터가 없거나 빈 배열인 경우
+  if (!data || data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{chartTitles[selectedCard]}</CardTitle>
+          <CardDescription>{chartDescriptions[selectedCard]}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartEmptyState message='데이터 집계중인 항목입니다.' />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // value가 null인 경우 (분석된 결과가 없는 경우)
+  const hasNullValues = data.some((item) => item.value === null);
+  if (hasNullValues) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>{chartTitles[selectedCard]}</CardTitle>
+          <CardDescription>{chartDescriptions[selectedCard]}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartEmptyState
+            message='분석된 결과가 없습니다.'
+            showDots={false}
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
   // REFERRAL은 파이차트, 나머지는 라인차트
   if (selectedCard === 'REFERRAL') {
     return (
-      <ServicePieChart
-        type={selectedCard}
-        data={data}
-      />
+      <Card className='flex flex-col'>
+        <CardHeader className='items-center pb-0'>
+          <CardTitle>{chartTitles[selectedCard]}</CardTitle>
+          <CardDescription>{chartDescriptions[selectedCard]}</CardDescription>
+        </CardHeader>
+        <CardContent className='flex-1 pb-0'>
+          <ServicePieChart data={data} />
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <ServiceLineChart
-      type={selectedCard}
-      data={data}
-    />
+    <Card>
+      <CardHeader>
+        <CardTitle>{chartTitles[selectedCard]}</CardTitle>
+        <CardDescription>{chartDescriptions[selectedCard]}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ServiceLineChart data={data} />
+      </CardContent>
+    </Card>
   );
 };
 

--- a/src/pages/service-dashboard/components/ServiceChart.tsx
+++ b/src/pages/service-dashboard/components/ServiceChart.tsx
@@ -1,5 +1,32 @@
-const ServiceChart = () => {
-  return <div className="border border-gary-200 rounded-lg h-[400px]">ServiceChart</div>;
+import { ServiceLineChart } from './LineChart';
+import { ServicePieChart } from './PieChart';
+import type {
+  ServiceDashboardType,
+  DashboardChartResponse,
+} from '@/types/service-dashboard';
+
+interface ServiceChartProps {
+  selectedCard: ServiceDashboardType;
+  data: DashboardChartResponse | null;
+}
+
+const ServiceChart = ({ selectedCard, data }: ServiceChartProps) => {
+  // REFERRAL은 파이차트, 나머지는 라인차트
+  if (selectedCard === 'REFERRAL') {
+    return (
+      <ServicePieChart
+        type={selectedCard}
+        data={data}
+      />
+    );
+  }
+
+  return (
+    <ServiceLineChart
+      type={selectedCard}
+      data={data}
+    />
+  );
 };
 
 export default ServiceChart;

--- a/src/pages/service-dashboard/components/ServiceChart.tsx
+++ b/src/pages/service-dashboard/components/ServiceChart.tsx
@@ -79,7 +79,10 @@ const ServiceChart = ({ selectedCard, data }: ServiceChartProps) => {
         <CardDescription>{chartDescriptions[selectedCard]}</CardDescription>
       </CardHeader>
       <CardContent>
-        <ServiceLineChart data={data} />
+        <ServiceLineChart
+          data={data}
+          chartType={selectedCard}
+        />
       </CardContent>
     </Card>
   );

--- a/src/pages/service-dashboard/components/ServiceReport.tsx
+++ b/src/pages/service-dashboard/components/ServiceReport.tsx
@@ -40,18 +40,21 @@ const ServiceReport = ({ data }: ServiceReportProps) => {
               <div className='flex items-start gap-3'>
                 <ChartPieIcon className='w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0' />
                 <p className='text-sm leading-relaxed'>
-                  {data.mostUsedFeature}
+                  가장 많이 사용하는 기능은 {data.mostUsedFeature} 입니다.
                 </p>
               </div>
               <div className='flex items-start gap-3'>
                 <ExclamationTriangleIcon className='w-5 h-5 text-orange-500 mt-0.5 flex-shrink-0' />
                 <p className='text-sm leading-relaxed'>
-                  {data.mostDroppedFeature}
+                  사용자가 가장 많이 이탈한 기능은 {data.mostDroppedFeature}{' '}
+                  입니다.
                 </p>
               </div>
               <div className='flex items-start gap-3'>
                 <ChartBarIcon className='w-5 h-5 text-green-500 mt-0.5 flex-shrink-0' />
-                <p className='text-sm leading-relaxed'>{data.mostEntryPath}</p>
+                <p className='text-sm leading-relaxed'>
+                  이번달 유입이 많은 기능은 {data.mostEntryPath} 입니다.
+                </p>
               </div>
             </>
           ) : (

--- a/src/pages/service-dashboard/components/ServiceReport.tsx
+++ b/src/pages/service-dashboard/components/ServiceReport.tsx
@@ -1,67 +1,63 @@
 import { useState } from 'react';
 import { Card } from '@/components/ui/card';
+import type { DashboardAISummaryResponse } from '@/types/service-dashboard';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
+  ChartPieIcon,
+  ExclamationTriangleIcon,
+  ChartBarIcon,
+} from '@heroicons/react/24/outline';
 
 import SparklesIcon from '@/assets/icons/service-dashboard/sparkle-icon.svg?react';
 import SmartReportModal from './SmartReportModal';
 
-const ServiceReport = () => {
+interface ServiceReportProps {
+  data: DashboardAISummaryResponse | null;
+}
+
+const ServiceReport = ({ data }: ServiceReportProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+
+  // 현재 날짜에서 월 추출
+  const currentMonth = new Date().getMonth() + 1; // getMonth()는 0부터 시작하므로 +1
 
   return (
     <>
-      <Card className='h-full p-4 flex flex-col shadow-none rounded-lg'>
+      <Card className='h-full p-6 flex flex-col shadow-none rounded-lg'>
         <div className='flex items-center justify-between'>
           <h2 className='text-lg font-medium text-[#4983EF] flex items-center gap-2'>
             한달 리포트 요약
             <SparklesIcon className='w-4 h-4 opacity-50 ' />
           </h2>
-          <Select defaultValue='month'>
-            <SelectTrigger className='w-[100px] bg-white shadow-none'>
-              <SelectValue placeholder='한달' />
-            </SelectTrigger>
-            <SelectContent className='w-[100px] min-w-[100px]'>
-              <SelectItem value='month'>한달</SelectItem>
-              <SelectItem value='week'>일주일</SelectItem>
-              <SelectItem value='day'>하루</SelectItem>
-            </SelectContent>
-          </Select>
         </div>
 
-        <div className='w-full bg-blue-50 rounded-full py-2 px-4 text-center text-gray-600 font-medium'>
-          <Select defaultValue='04'>
-            <SelectTrigger className='w-full bg-transparent border-none text-center text-lg font-medium shadow-none cursor-default'>
-              <SelectValue placeholder='월 선택' />
-            </SelectTrigger>
-            <SelectContent>
-              {Array.from({ length: 12 }, (_, i) => i + 1).map((month) => (
-                <SelectItem
-                  key={month}
-                  value={month.toString().padStart(2, '0')}>
-                  {month}월
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+        <div className='w-full bg-blue-50 rounded-full p-4 text-center text-gray-600 font-medium'>
+          <span className='text-xl font-medium'>{currentMonth}월</span>
         </div>
 
-        <div className='flex-1 flex flex-col justify-center space-y-1 text-gray-600 py-1'>
-          <p>1. 가장 많이 사용한 기능은 000 입니다.</p>
-          <p>2. 가장 이탈률이 많은 기능은 000 입니다.</p>
-          <p>3. 0000 경로에서 가장 많은 사용자가 유입되었습니다.</p>
+        <div className='flex-1 flex flex-col space-y-3 text-gray-600 py-1'>
+          {data ? (
+            <>
+              <div className='flex items-start gap-3'>
+                <ChartPieIcon className='w-5 h-5 text-blue-500 mt-0.5 flex-shrink-0' />
+                <p className='text-sm leading-relaxed'>
+                  {data.mostUsedFeature}
+                </p>
+              </div>
+              <div className='flex items-start gap-3'>
+                <ExclamationTriangleIcon className='w-5 h-5 text-orange-500 mt-0.5 flex-shrink-0' />
+                <p className='text-sm leading-relaxed'>
+                  {data.mostDroppedFeature}
+                </p>
+              </div>
+              <div className='flex items-start gap-3'>
+                <ChartBarIcon className='w-5 h-5 text-green-500 mt-0.5 flex-shrink-0' />
+                <p className='text-sm leading-relaxed'>{data.mostEntryPath}</p>
+              </div>
+            </>
+          ) : (
+            <p className='text-gray-400 text-sm'>데이터가 없습니다.</p>
+          )}
         </div>
-
-        <button
-          onClick={() => setIsModalOpen(true)}
-          className='w-full py-3 text-gray-500 border border-gray-200 rounded-md hover:bg-gray-50 transition-colors cursor-pointer'>
-          더보기
-        </button>
       </Card>
 
       <SmartReportModal

--- a/src/pages/service-dashboard/components/StatCard.tsx
+++ b/src/pages/service-dashboard/components/StatCard.tsx
@@ -23,8 +23,8 @@ interface StatCardProps {
 const iconMap = {
   DAU: DAUIcon,
   MAU: MAUIcon,
-  CONTENTS: ContentsIcon,
-  NEW_USERS: NewUsersIcon,
+  CONTENT: ContentsIcon,
+  INFLOW: NewUsersIcon,
   REFERRAL: RevisionsIcon, // 유입경로는 기존 revisiting 아이콘 사용
 };
 
@@ -49,7 +49,11 @@ const StatCard = ({
           ? 'bg-white shadow-blue rounded-lg z-10 w-[calc(100%+3rem)]'
           : 'bg-gray-50 hover:bg-gray-100 w-full'
       }
-      ${!isActive && title !== 'CONTENTS' ? 'border-r border-gray-200' : ''}`}>
+                  ${
+                    !isActive && title !== 'CONTENT'
+                      ? 'border-r border-gray-200'
+                      : ''
+                  }`}>
       <div className='flex items-start gap-4'>
         <Icon className='h-14 w-14' />
 

--- a/src/pages/service-dashboard/components/StatCard.tsx
+++ b/src/pages/service-dashboard/components/StatCard.tsx
@@ -39,6 +39,35 @@ const StatCard = ({
 }: StatCardProps) => {
   const Icon = iconMap[icon];
 
+  const getTrendText = () => {
+    switch (title) {
+      case 'DAU':
+        return `기준일 1일 전 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
+          trend.value,
+        )}%가 변동되었습니다.`;
+      case 'MAU':
+        return `이전 달 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
+          trend.value,
+        )}%가 변동되었습니다.`;
+      case 'CONTENT':
+        return `이전 달 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
+          trend.value,
+        )}%가 변동되었습니다.`;
+      case 'INFLOW':
+        return `기준일 1일 전 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
+          trend.value,
+        )}%가 변동되었습니다.`;
+      case 'REFERRAL':
+        return '해당 경로에서 사용자가 가장 많이 유입되었습니다.';
+      default:
+        return `${trend.isPositive ? '+' : '-'}${Math.abs(
+          trend.value,
+        )}% from last week`;
+    }
+  };
+
+  const isReferral = title === 'REFERRAL';
+
   return (
     <button
       type='button'
@@ -65,10 +94,13 @@ const StatCard = ({
           </div>
           <div
             className={`text-sm ${
-              trend.isPositive ? 'text-green-500' : 'text-red-500'
+              isReferral
+                ? 'text-gray-500'
+                : trend.isPositive
+                ? 'text-green-500'
+                : 'text-red-500'
             }`}>
-            {trend.isPositive ? '+' : '-'}
-            {Math.abs(trend.value)}% from last week
+            {getTrendText()}
           </div>
         </div>
       </div>

--- a/src/pages/service-dashboard/components/StatCard.tsx
+++ b/src/pages/service-dashboard/components/StatCard.tsx
@@ -3,15 +3,29 @@ import MAUIcon from '@/assets/icons/service-dashboard/MAU-icon.svg?react';
 import ContentsIcon from '@/assets/icons/service-dashboard/contents-icon.svg?react';
 import NewUsersIcon from '@/assets/icons/service-dashboard/new-user-icon.svg?react';
 import RevisionsIcon from '@/assets/icons/service-dashboard/revisiting-icon.svg?react';
+import type { ServiceDashboardType } from '@/types/service-dashboard';
 
 import { statTitleMap } from '@/constants/service-dashboard/stat-card';
+
+interface StatCardProps {
+  title: ServiceDashboardType;
+  value: string | number;
+  icon: ServiceDashboardType;
+  trend: {
+    value: number;
+    isPositive: boolean;
+  };
+  unit?: string;
+  isActive?: boolean;
+  onClick?: () => void;
+}
 
 const iconMap = {
   DAU: DAUIcon,
   MAU: MAUIcon,
   CONTENTS: ContentsIcon,
   NEW_USERS: NewUsersIcon,
-  REVISIONS: RevisionsIcon,
+  REFERRAL: RevisionsIcon, // 유입경로는 기존 revisiting 아이콘 사용
 };
 
 const StatCard = ({

--- a/src/pages/service-dashboard/components/StatCard.tsx
+++ b/src/pages/service-dashboard/components/StatCard.tsx
@@ -44,24 +44,24 @@ const StatCard = ({
       case 'DAU':
         return `기준일 1일 전 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
           trend.value,
-        )}%가 변동되었습니다.`;
+        ).toFixed(1)}%가 변동되었습니다.`;
       case 'MAU':
         return `이전 달 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
           trend.value,
-        )}%가 변동되었습니다.`;
+        ).toFixed(1)}%가 변동되었습니다.`;
       case 'CONTENT':
         return `이전 달 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
           trend.value,
-        )}%가 변동되었습니다.`;
+        ).toFixed(1)}%가 변동되었습니다.`;
       case 'INFLOW':
         return `기준일 1일 전 대비 ${trend.isPositive ? '+' : '-'}${Math.abs(
           trend.value,
-        )}%가 변동되었습니다.`;
+        ).toFixed(1)}%가 변동되었습니다.`;
       case 'REFERRAL':
         return '해당 경로에서 사용자가 가장 많이 유입되었습니다.';
       default:
-        return `${trend.isPositive ? '+' : '-'}${Math.abs(
-          trend.value,
+        return `${trend.isPositive ? '+' : '-'}${Math.abs(trend.value).toFixed(
+          1,
         )}% from last week`;
     }
   };

--- a/src/pages/service-dashboard/components/StatCardGrid.tsx
+++ b/src/pages/service-dashboard/components/StatCardGrid.tsx
@@ -17,7 +17,15 @@ const StatCardGrid = ({
   data,
 }: StatCardGridProps) => {
   // API 데이터를 기반으로 카드 데이터 생성
-  const getCardData = (cardTitle: ServiceDashboardType) => {
+  const getCardData = (
+    cardTitle: ServiceDashboardType,
+  ): {
+    title: ServiceDashboardType;
+    value: string | number;
+    icon: ServiceDashboardType;
+    trend: { value: number; isPositive: boolean };
+    unit?: string;
+  } => {
     if (!data) {
       // 데이터가 없으면 기본값 사용
       return (
@@ -39,10 +47,10 @@ const StatCardGrid = ({
           return label.includes('일간') || label.includes('DAU');
         case 'MAU':
           return label.includes('월간') || label.includes('MAU');
-        case 'CONTENTS':
-          return label.includes('콘텐츠') || label.includes('CONTENTS');
-        case 'NEW_USERS':
-          return label.includes('신규') || label.includes('NEW');
+        case 'CONTENT':
+          return label.includes('콘텐츠') || label.includes('CONTENT');
+        case 'INFLOW':
+          return label.includes('신규') || label.includes('INFLOW');
         case 'REFERRAL':
           return label.includes('유입') || label.includes('REFERRAL');
         default:

--- a/src/pages/service-dashboard/components/StatCardGrid.tsx
+++ b/src/pages/service-dashboard/components/StatCardGrid.tsx
@@ -1,28 +1,114 @@
 import StatCard from './StatCard';
 import { statCards } from '@/constants/service-dashboard/stat-card';
+import type {
+  ServiceDashboardType,
+  DashboardSummaryResponse,
+} from '@/types/service-dashboard';
 
 interface StatCardGridProps {
-  selectedCard: IconType;
-  onCardSelect: (cardTitle: IconType) => void;
+  selectedCard: ServiceDashboardType;
+  onCardSelect: (cardTitle: ServiceDashboardType) => void;
+  data?: DashboardSummaryResponse;
 }
 
-const StatCardGrid = ({ selectedCard, onCardSelect }: StatCardGridProps) => {
+const StatCardGrid = ({
+  selectedCard,
+  onCardSelect,
+  data,
+}: StatCardGridProps) => {
+  // API 데이터를 기반으로 카드 데이터 생성
+  const getCardData = (cardTitle: ServiceDashboardType) => {
+    if (!data) {
+      // 데이터가 없으면 기본값 사용
+      return (
+        statCards.find((card) => card.title === cardTitle) || {
+          title: cardTitle,
+          value: '0',
+          icon: cardTitle,
+          trend: { value: 0, isPositive: true },
+          unit: '',
+        }
+      );
+    }
+
+    // API 데이터에서 해당하는 항목 찾기
+    const apiItem = data.find((item) => {
+      const label = item.label;
+      switch (cardTitle) {
+        case 'DAU':
+          return label.includes('일간') || label.includes('DAU');
+        case 'MAU':
+          return label.includes('월간') || label.includes('MAU');
+        case 'CONTENTS':
+          return label.includes('콘텐츠') || label.includes('CONTENTS');
+        case 'NEW_USERS':
+          return label.includes('신규') || label.includes('NEW');
+        case 'REFERRAL':
+          return label.includes('유입') || label.includes('REFERRAL');
+        default:
+          return false;
+      }
+    });
+
+    if (apiItem) {
+      // 유입 경로의 경우 특별 처리
+      if (cardTitle === 'REFERRAL') {
+        return {
+          title: cardTitle,
+          value: apiItem.value || '데이터 없음',
+          icon: cardTitle,
+          trend: {
+            value: 0,
+            isPositive: true,
+          },
+          unit: '',
+        };
+      }
+
+      return {
+        title: cardTitle,
+        value: apiItem.value,
+        icon: cardTitle,
+        trend: {
+          value: Math.abs(apiItem.changeRate || 0),
+          isPositive: (apiItem.changeRate || 0) >= 0,
+        },
+        unit: apiItem.unit || '',
+      };
+    }
+
+    // API 데이터에서 찾지 못한 경우 기본값 사용
+    return (
+      statCards.find((card) => card.title === cardTitle) || {
+        title: cardTitle,
+        value: '0',
+        icon: cardTitle,
+        trend: { value: 0, isPositive: true },
+        unit: '',
+      }
+    );
+  };
+
   return (
     <div className='grid grid-cols-1 gap-y-4 h-full border border-gray-200 bg-gray-50 rounded-lg md:grid-cols-2 lg:grid-cols-3 overflow-visible'>
-      {statCards.map((card) => (
-        <div
-          key={card.title}
-          className='h-full'>
-          <StatCard
-            title={card.title}
-            value={card.value}
-            icon={card.icon}
-            trend={card.trend}
-            isActive={card.title === selectedCard}
-            onClick={() => onCardSelect(card.title)}
-          />
-        </div>
-      ))}
+      {statCards.map((card) => {
+        const cardData = getCardData(card.title);
+        return (
+          <div
+            key={card.title}
+            className='h-full'>
+            <StatCard
+              title={cardData.title}
+              value={cardData.value}
+              icon={cardData.icon}
+              trend={cardData.trend}
+              unit={cardData.unit}
+              isActive={card.title === selectedCard}
+              onClick={() => onCardSelect(card.title)}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -6,6 +6,7 @@ import { fetchAdminInfo, refreshAccessTokenAPI } from '../apis/auth';
 import { ROLE_PERMISSIONS } from '@/constants/permissions';
 import { AdminRole } from '@/types/admins';
 import { useToast } from '@/hooks/useToast';
+import SplitText from '@/components/react-bits/SplitText';
 
 export default function ProtectedRoute() {
   const accessToken = useAuthStore((state) => state.accessToken);
@@ -37,9 +38,42 @@ export default function ProtectedRoute() {
     };
 
     initialize();
-  }, []);
+  }, [accessToken, setAccessToken, setUser]);
 
-  if (loading) return <h1>Loading</h1>;
+  if (loading) {
+    return (
+      <div className='min-h-screen flex flex-col items-center justify-center bg-gray-50 space-y-12'>
+        {/* 로딩 텍스트 */}
+        <div className='text-center space-y-6'>
+          <p className='flex flex-col items-center justify-center'>
+            <SplitText
+              text='RoomE 관리자'
+              className='text-4xl font-bold text-gray-800'
+              tag='h1'
+              delay={100}
+              duration={0.4}
+              from={{ opacity: 0, y: 30, scale: 0.8 }}
+              to={{ opacity: 1, y: 0, scale: 1 }}
+            />
+            <SplitText
+              text='시스템을 초기화하는 중...'
+              className='text-xl text-gray-500'
+              tag='p'
+              delay={200}
+              duration={0.4}
+              from={{ opacity: 0, y: 20 }}
+              to={{ opacity: 1, y: 0 }}
+            />
+          </p>
+        </div>
+
+        {/* 진행률 표시 */}
+        <div className='w-80 bg-gray-200 rounded-full h-3 overflow-hidden'>
+          <div className='h-full bg-gradient-to-r from-blue-500 to-purple-500 rounded-full animate-pulse'></div>
+        </div>
+      </div>
+    );
+  }
 
   const isAuthenticated = !!useAuthStore.getState().accessToken;
 

--- a/src/types/service-dashboard.d.ts
+++ b/src/types/service-dashboard.d.ts
@@ -29,7 +29,7 @@ export type DashboardSummaryResponse = DashboardSummaryItem[];
 // 2. 서비스 사용 지표 차트 조회(주간) API 응답 타입
 export interface DashboardChartDataPoint {
   xlabels: string; // "YYYY-MM-DD" 형식의 날짜
-  value: string; // 차트 값 (문자열로 반환됨)
+  value: string | null; // 차트 값 (문자열로 반환됨, null일 수 있음)
 }
 
 export type DashboardChartResponse = DashboardChartDataPoint[];

--- a/src/types/service-dashboard.d.ts
+++ b/src/types/service-dashboard.d.ts
@@ -1,10 +1,15 @@
-// 기존 StatCard 컴포넌트용 타입들
-type IconType = 'DAU' | 'MAU' | 'CONTENTS' | 'NEW_USERS' | 'REVISIONS';
+// 서비스 대시보드 타입들
+type ServiceDashboardType =
+  | 'DAU'
+  | 'MAU'
+  | 'CONTENTS'
+  | 'NEW_USERS'
+  | 'REFERRAL';
 
 interface StatCardProps {
-  title: IconType;
+  title: ServiceDashboardType;
   value: string | number;
-  icon: IconType;
+  icon: ServiceDashboardType;
   trend: {
     value: number;
     isPositive: boolean;

--- a/src/types/service-dashboard.d.ts
+++ b/src/types/service-dashboard.d.ts
@@ -1,3 +1,4 @@
+// 기존 StatCard 컴포넌트용 타입들
 type IconType = 'DAU' | 'MAU' | 'CONTENTS' | 'NEW_USERS' | 'REVISIONS';
 
 interface StatCardProps {
@@ -11,4 +12,33 @@ interface StatCardProps {
   unit?: string;
   isActive?: boolean;
   onClick?: () => void;
+}
+
+// ===== 서비스 대시보드 API 타입 정의 =====
+
+// 1. 서비스 사용 지표 카드 인덱스 조회 API 응답 타입
+export interface DashboardSummaryItem {
+  label: string; // "월간 활성 사용자수(MAU)", "일간 활성 사용자수(DAU)" 등
+  value: number; // 실제 수치 값
+  unit: string | null; // "명", "건" 등 단위 (유입 경로의 경우 null)
+  changeRate: number | null; // 변화율 (유입 경로의 경우 null)
+}
+
+export type DashboardSummaryResponse = DashboardSummaryItem[];
+
+// 2. 서비스 사용 지표 차트 조회(주간) API 응답 타입
+export interface DashboardChartDataPoint {
+  xLabels: string; // "YYYY-MM-DD" 형식의 날짜
+  value: string; // 차트 값 (문자열로 반환됨)
+}
+
+export interface DashboardChartResponse {
+  data: DashboardChartDataPoint[];
+}
+
+// 3. 서비스 사용 지표 요약 조회(AI) API 응답 타입
+export interface DashboardAISummaryResponse {
+  mostUsedFeature: string; // "가장 많이 사용한 기능은 000 입니다."
+  mostDroppedFeature: string; // "가장 이탈률이 많은 기능은 00 입니다."
+  mostEntryPath: string; // "0000 경로에서 가장 많은 사용자가 유입되었습니다."
 }

--- a/src/types/service-dashboard.d.ts
+++ b/src/types/service-dashboard.d.ts
@@ -1,10 +1,5 @@
 // 서비스 대시보드 타입들
-type ServiceDashboardType =
-  | 'DAU'
-  | 'MAU'
-  | 'CONTENTS'
-  | 'NEW_USERS'
-  | 'REFERRAL';
+type ServiceDashboardType = 'DAU' | 'MAU' | 'CONTENT' | 'INFLOW' | 'REFERRAL';
 
 interface StatCardProps {
   title: ServiceDashboardType;
@@ -33,13 +28,11 @@ export type DashboardSummaryResponse = DashboardSummaryItem[];
 
 // 2. 서비스 사용 지표 차트 조회(주간) API 응답 타입
 export interface DashboardChartDataPoint {
-  xLabels: string; // "YYYY-MM-DD" 형식의 날짜
+  xlabels: string; // "YYYY-MM-DD" 형식의 날짜
   value: string; // 차트 값 (문자열로 반환됨)
 }
 
-export interface DashboardChartResponse {
-  data: DashboardChartDataPoint[];
-}
+export type DashboardChartResponse = DashboardChartDataPoint[];
 
 // 3. 서비스 사용 지표 요약 조회(AI) API 응답 타입
 export interface DashboardAISummaryResponse {


### PR DESCRIPTION
## ✨ 반영 브랜치
`Feat/service-dashboard-61` -> `dev`

## 📝 설명
서비스 대시보드 기능 구현 및 UI 개선
<img width="3420" height="1936" alt="image" src="https://github.com/user-attachments/assets/e77cec82-3170-4e6c-bead-e86a262582e3" />
![Uploading image.png…]()


## ✅ 변경 사항
- [x] 카드 인덱스 + 차트 조회 타입 수정
  - 파일: `src/types/service-dashboard.d.ts`
- [x] 카드 인덱스 API 수정
- [x] 카드 인덱스별 차트 API 구현
- [x] 리포트 API 구현
- [x] SSE로 알림 업데이트시 토스트 피드백 구현
  - 파일: `src/hooks/notification/useNotificationSSE.ts`
  - 변경사항: `showInfoToast` 함수 호출로 새로운 알림 도착시 토스트 표시
- [x] 차트 날짜 표시 형식 개선
  - 파일: `src/pages/service-dashboard/components/LineChart.tsx`, `src/pages/service-dashboard/components/ServiceChart.tsx`
  - 변경사항: 차트 타입별 날짜 형식 구분 (DAU/신규사용자: 일 단위, MAU/콘텐츠수: 월 단위)

## 📢 이슈 정보
#61